### PR TITLE
Python 3.6 compatibility and upgrade ONIX XSDs to 3.0.6+cl45

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,28 @@
 language: python
-python: 3.5
 sudo: false
 env:
   global:
     LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
-  matrix:
-    - TOXENV=check
-    - TOXENV=2.6
-    - TOXENV=2.6-nocover
-    - TOXENV=2.7
-    - TOXENV=2.7-nocover
-    - TOXENV=3.3
-    - TOXENV=3.3-nocover
-    - TOXENV=3.4
-    - TOXENV=3.4-nocover
-    - TOXENV=3.5
-    - TOXENV=3.5-nocover
-    - TOXENV=pypy-nocover
+matrix:
+  include:
+    - name: "Check"
+      python: 3.6
+      env: TOXENV=check
+    - name: "Python 2.7"
+      python: 2.7
+      env: TOXENV=2.7
+    - name: "Python 3.4"
+      python: 3.4
+      env: TOXENV=3.4
+    - name: "Python 3.5"
+      python: 3.5
+      env: TOXENV=3.5
+    - name: "Python 3.6"
+      python: 3.6
+      env: TOXENV=3.6
+    - name: "PyPy"
+      python: pypy
+      env: TOXENV=pypy
 before_install:
   - python --version
   - virtualenv --version
@@ -31,4 +37,3 @@ notifications:
   email:
     on_success: never
     on_failure: always
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,6 @@ environment:
       PYTHON_HOME: "C:\\Python27"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
-    - TOXENV: "2.7-nocover"
-      TOXPYTHON: "C:\\Python27\\python.exe"
-      WINDOWS_SDK_VERSION: "v7.0"
-      PYTHON_HOME: "C:\\Python27"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
 init:
   - "ECHO %TOXENV%"
   - ps: "ls C:\\Python*"
@@ -27,6 +21,6 @@ test_script:
   - "%PYTHON_HOME%\\Scripts\\pip --version"
   - "%WITH_COMPILER% %PYTHON_HOME%\\Scripts\\tox"
 after_test:
-  - "IF \"%TOXENV:~-8,8%\" == \"-nocover\" %WITH_COMPILER% %TOXPYTHON% setup.py bdist_wheel"
+  - "%WITH_COMPILER% %TOXPYTHON% setup.py bdist_wheel"
 artifacts:
   - path: dist\*

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ release = clean --all sdist bdist_wheel upload
 max-line-length = 140
 exclude = tests/*,*/migrations/*,*/south_migrations/*
 
-[pytest]
+[tool:pytest]
 norecursedirs =
     .git
     .tox

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*names, **kwargs):
     ).read()
 
 
-dependencies = ['lxml', 'defusedxml', 'isbnlib', 'PyYAML']
+dependencies = ['six', 'lxml', 'defusedxml', 'isbnlib', 'PyYAML']
 
 if platform.python_implementation() != 'PyPy':
     dependencies.append('scandir')

--- a/src/onixcheck/__main__.py
+++ b/src/onixcheck/__main__.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser, FileType
 from onixcheck import validate, __version__
 from onixcheck.exeptions import get_logger
 from onixcheck.utils import iter_files
-
+from six.moves import getcwd
 
 DEFAULT_EXTENSIONS = ('xml', 'onx', 'onix')
 log = get_logger()
@@ -65,7 +65,7 @@ def main(argv=None):
     log.debug('TYPE of path: %s' % type(args.path))
     # validate current working dir
     if not args.infile and not args.path:
-        args.path = os.getcwdu()
+        args.path = getcwd()
         log.debug('NEW TYPE of path: %s' % type(args.path))
 
     all_valid = True

--- a/src/onixcheck/__main__.py
+++ b/src/onixcheck/__main__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, print_function
-import os
 import sys
 import logging
 from argparse import ArgumentParser, FileType

--- a/src/onixcheck/models.py
+++ b/src/onixcheck/models.py
@@ -180,6 +180,7 @@ class OnixMeta(_BaseMeta):
         except KeyError:
             raise OnixError('Found no {2} schema for ONIX {0} {1}'.format(*key))
 
+
 _BaseMessage = namedtuple('Message', 'level validator location message error_type')
 
 
@@ -210,17 +211,16 @@ class Message(_BaseMessage):
         :param str filename: Optional filename to prefix error location
         :return Message:
         """
-        l = logentry
-        location = '%s:%s:%s' % (filename, l.line, l.column)
-        message = l.message or ''
+        location = '%s:%s:%s' % (filename, logentry.line, logentry.column)
+        message = logentry.message or ''
         message = re.sub('({.*?})', '', message)
 
         return cls(
-            level=l.level_name,
-            validator=l.domain_name,
+            level=logentry.level_name,
+            validator=logentry.domain_name,
             location=location,
             message=message,
-            error_type=l.type_name
+            error_type=logentry.type_name
         )
 
     @classmethod

--- a/src/onixcheck/onixfix.py
+++ b/src/onixcheck/onixfix.py
@@ -194,6 +194,7 @@ class OnixFix(object):
             msg = 'Invalid decimal value %s' % el.text
             self.add_message(msg, path, el)
 
+
 if __name__ == '__main__':
     from onixcheck import profiles, data
 

--- a/src/onixcheck/schema/xsd3.0/ONIX_BookProduct_3.0_reference.xsd
+++ b/src/onixcheck/schema/xsd3.0/ONIX_BookProduct_3.0_reference.xsd
@@ -15,12 +15,12 @@
 	*          Recent revisions: Graham Bell         *
 	*                                                *
 	*                  Release 3.0                   *
-	*                   Revision 3                   *
-	*                Status: RELEASED                *
+	*                   Revision 6                   *
+	*               Status: RELEASED                 *
 	*            Release date: 2009-04-09            *
-	*              Revised: 2016-04-25               *
+	*              Revised: 2019-04-26               *
 	*                                                *
-	*             (c) 2000-2016 EDItEUR              *
+	*             (c) 2000-2019 EDItEUR              *
 	*             http://www.editeur.org/            *
 	*                                                *
 	**************************************************
@@ -58,6 +58,33 @@
 
 	SCHEMA REVISION HISTORY (IN REVERSE CHRONOLOGICAL ORDER)
 
+	2019-04-26: ONIX for Books 3.0 revision 6
+	            1. Added <Measure> within <ProductPart>
+	            2. Made <WebsiteLink> repeatable, added @language
+
+	2018-10-26: ONIX for Books 3.0 revision 5
+	            1. Added <AVItem> within <ContentItem>, as an alternative to <TextItem>
+	            2. Added <PalletQuantity> within <Supplier>
+	            3. Added <TaxExempt/> empty element
+	            4. Ensure Blocks 2, 3, 5 can be blank
+
+	2018-02-02: Enforce 'if and only if' on <PositionOnProduct> in <Price>
+
+	2017-11-26: corrected content model for <InitialPrintRun> to match documentation
+
+	2017-10-26: ONIX for Books 3.0 revision 4
+	            1. Added <SupplyContact> within <SupplyDetail>
+	            2. Added <PricePartDescription> in <Tax>
+	            3. Added <EpubTechnicalProtection> and <EpubLicense> in <Price>
+	            4. Modified <CollectionSequenceNumber> to accept hyphen for unordered levels in numbering hierarchy
+	            5. Added <Reserved> within <Stock>
+	            6. Added <Language> in <ContentItem>
+	            7. Used gp.authorship in <Collection> and <ContentItem>
+
+	2017-10-19: Corrected regex for dt.MultiLevelNumber
+
+	2017-05-22: Simplified expression of data model for <Territory>
+
 	2016-04-25: ONIX for Books 3.0 revision 3
 	            1. added Event as near-synonym for Conference
 	               a. choose either elements labelled <Event…> OR <Conference…>, but cannot mix in one <Product> record
@@ -85,7 +112,7 @@
 	2016-01-24: 1. enforce positive (>= 0), strict positive (> 0) or percentage (0..100) real numbers in various fields
 	            2. enforce positive (0, 1, 2…) or strict positive (1, 2, 3…) integers in various fields
 
-	               note these changes were included in 'strict' version of schema from 2015-01-24
+	               note these changes had been included in a 'strict' version of schema from 2015-01-24
 
 	2015-07-29: corrected Flow to dt.NonEmptyString in ConferenceName to match documentation
 
@@ -237,6 +264,35 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://ns.editeur.org/onix/3.0/reference" xmlns="http://ns.editeur.org/onix/3.0/reference">
 	<xs:include schemaLocation="ONIX_BookProduct_CodeLists.xsd" />
 	<xs:include schemaLocation="ONIX_XHTML_Subset.xsd" />
+
+	<xs:element name="ONIXMessage">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Header" />
+				<xs:choice>
+					<xs:element ref="NoProduct" />
+					<xs:element maxOccurs="unbounded" ref="Product" />
+				</xs:choice>
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="ONIXMessage" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="ONIXmessage" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+			<xs:attributeGroup ref="releaseAttribute" />
+		</xs:complexType>
+	</xs:element>
+
 	<xs:element name="Addressee">
 		<xs:complexType>
 			<xs:sequence>
@@ -532,29 +588,6 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="AncillaryContentType">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List25">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="AncillaryContentType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="x423" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="AncillaryContentDescription">
 		<xs:complexType mixed="true">
 			<xs:complexContent>
@@ -578,6 +611,29 @@
 					<xs:attributeGroup ref="textformatAttribute" />
 				</xs:extension>
 			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AncillaryContentType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List25">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="AncillaryContentType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x423" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="Audience">
@@ -811,6 +867,124 @@
 						<xs:simpleType>
 							<xs:restriction base="xs:token">
 								<xs:enumeration value="b076" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AVDuration">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.TimeOrDuration">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="AVDuration" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x544" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AVItem">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AVItemType" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="AVItemIdentifier" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="TimeRun" />
+				<xs:element minOccurs="0" ref="AVDuration" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="AVItem" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="avitem" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AVItemIdentifier">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AVItemIDType" />
+				<xs:element minOccurs="0" ref="IDTypeName" />
+				<xs:element ref="IDValue" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="AVItemIdentifier" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="avitemidentifier" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AVItemIDType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List241">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="AVItemIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x541" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AVItemType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List240">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="AVItemType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x540" />
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>
@@ -1298,10 +1472,7 @@
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="CollectionIdentifier" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="CollectionSequence" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="TitleDetail" />
-				<xs:sequence minOccurs="0">
-					<xs:element maxOccurs="unbounded" ref="Contributor" />
-					<xs:element minOccurs="0" maxOccurs="unbounded" ref="ContributorStatement" />
-				</xs:sequence>
+				<xs:group ref="gp.authorship" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -1394,7 +1565,7 @@
 	<xs:element name="CollectionSequenceNumber">
 		<xs:complexType>
 			<xs:simpleContent>
-				<xs:extension base="dt.MultiLevelNumber">
+				<xs:extension base="dt.MultiLevelNumberOrHyphen">
 					<xs:attribute name="refname">
 						<xs:simpleType>
 							<xs:restriction base="xs:token">
@@ -1827,29 +1998,6 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="ConferenceSponsorIDType">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List44">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="ConferenceSponsorIDType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="b391" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="ConferenceSponsorIdentifier">
 		<xs:complexType>
 			<xs:sequence>
@@ -1872,6 +2020,29 @@
 				</xs:simpleType>
 			</xs:attribute>
 			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="ConferenceSponsorIDType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List44">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="ConferenceSponsorIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="b391" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="ConferenceTheme">
@@ -1995,7 +2166,7 @@
 	<xs:element name="ContentDetail">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element maxOccurs="unbounded" ref="ContentItem" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="ContentItem" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -2018,7 +2189,10 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element minOccurs="0" ref="LevelSequenceNumber" />
-				<xs:element ref="TextItem" />
+				<xs:choice>
+					<xs:element ref="TextItem" />
+					<xs:element ref="AVItem" />
+				</xs:choice>
 				<xs:choice>
 					<xs:sequence>
 						<xs:element ref="ComponentTypeName" />
@@ -2030,14 +2204,11 @@
 						<xs:element maxOccurs="unbounded" ref="TitleDetail" />
 					</xs:sequence>
 				</xs:choice>
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="Contributor" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="Subject" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="NameAsSubject" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="TextContent" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="CitedContent" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="SupportingResource" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="RelatedWork" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="RelatedProduct" />
+				<xs:group ref="gp.authorship" />
+				<xs:group ref="gp.languages" />
+				<xs:group ref="gp.subjects" />
+				<xs:group ref="gp.descriptions" />
+				<xs:group ref="gp.related_materials" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -2403,29 +2574,6 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="CopyrightOwnerIDType">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List44">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="CopyrightOwnerIDType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="b392" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="CopyrightOwnerIdentifier">
 		<xs:complexType>
 			<xs:sequence>
@@ -2448,6 +2596,29 @@
 				</xs:simpleType>
 			</xs:attribute>
 			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="CopyrightOwnerIDType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List44">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="CopyrightOwnerIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="b392" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="CopyrightStatement">
@@ -2642,14 +2813,6 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
-	<xs:simpleType name="CountryCodeList">
-		<xs:restriction>
-			<xs:simpleType>
-				<xs:list itemType="List91" />
-			</xs:simpleType>
-			<xs:minLength value="1" />
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:element name="CountryOfManufacture">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -2887,14 +3050,14 @@
 			<xs:sequence>
 				<xs:group ref="gp.product_form" />
 				<xs:group ref="gp.collections" />
-				<xs:group ref="gp.title" />
+				<xs:group ref="gp.titles" />
 				<xs:group ref="gp.authorship" />
-				<xs:group ref="gp.event" />
-				<xs:group ref="gp.edition" />
-				<xs:group ref="gp.language" />
+				<xs:group ref="gp.events" />
+				<xs:group ref="gp.editions" />
+				<xs:group ref="gp.languages" />
 				<xs:group ref="gp.extents" />
-				<xs:group ref="gp.subject" />
-				<xs:group ref="gp.audience" />
+				<xs:group ref="gp.subjects" />
+				<xs:group ref="gp.audiences" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -2992,6 +3155,30 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="DiscountCoded">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="DiscountCodeType" />
+				<xs:element minOccurs="0" ref="DiscountCodeTypeName" />
+				<xs:element ref="DiscountCode" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="DiscountCoded" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="discountcoded" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="DiscountCodeType">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -3039,28 +3226,27 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="DiscountCoded">
+	<xs:element name="DiscountPercent">
 		<xs:complexType>
-			<xs:sequence>
-				<xs:element ref="DiscountCodeType" />
-				<xs:element minOccurs="0" ref="DiscountCodeTypeName" />
-				<xs:element ref="DiscountCode" />
-			</xs:sequence>
-			<xs:attribute name="refname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="DiscountCoded" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attribute name="shortname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="discountcoded" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attributeGroup ref="generalAttributes" />
+			<xs:simpleContent>
+				<xs:extension base="dt.PercentDecimal">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="DiscountPercent" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="j267" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="DiscountType">
@@ -3223,6 +3409,29 @@
 					</xs:attribute>
 					<xs:attributeGroup ref="generalAttributes" />
 					<xs:attributeGroup ref="dateformatAttribute" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="EndTime">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.TimeOrDuration">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="EndTime" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x543" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
 				</xs:extension>
 			</xs:simpleContent>
 		</xs:complexType>
@@ -3709,29 +3918,6 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="EventSponsorIDType">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List44">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="EventSponsorIDType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="x522" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="EventSponsorIdentifier">
 		<xs:complexType>
 			<xs:sequence>
@@ -3754,6 +3940,29 @@
 				</xs:simpleType>
 			</xs:attribute>
 			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="EventSponsorIDType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List44">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="EventSponsorIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x522" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="EventTheme">
@@ -4381,9 +4590,9 @@
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="InitialPrintRun">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="dt.NonEmptyString">
+		<xs:complexType mixed="true">
+			<xs:complexContent>
+				<xs:extension base="Flow">
 					<xs:attribute name="refname">
 						<xs:simpleType>
 							<xs:restriction base="xs:token">
@@ -4402,7 +4611,7 @@
 					<xs:attributeGroup ref="languageAttribute" />
 					<xs:attributeGroup ref="textformatAttribute" />
 				</xs:extension>
-			</xs:simpleContent>
+			</xs:complexContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="KeyNames">
@@ -5512,33 +5721,6 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="ONIXMessage">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element ref="Header" />
-				<xs:choice>
-					<xs:element ref="NoProduct" />
-					<xs:element maxOccurs="unbounded" ref="Product" />
-				</xs:choice>
-			</xs:sequence>
-			<xs:attribute name="refname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="ONIXMessage" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attribute name="shortname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="ONIXmessage" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attributeGroup ref="generalAttributes" />
-			<xs:attributeGroup ref="releaseAttribute" />
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="OnHand">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -5724,6 +5906,29 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="PalletQuantity">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.StrictPositiveInteger">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="PalletQuantity" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x545" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="PartNumber">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -5764,29 +5969,6 @@
 						<xs:simpleType>
 							<xs:restriction base="xs:token">
 								<xs:enumeration value="b337" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="DiscountPercent">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="dt.PercentDecimal">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="DiscountPercent" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="j267" />
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>
@@ -5925,7 +6107,9 @@
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="PriceIdentifier" />
 				<xs:element minOccurs="0" ref="PriceType" />
 				<xs:element minOccurs="0" ref="PriceQualifier" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="EpubTechnicalProtection" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="PriceConstraint" />
+				<xs:element minOccurs="0" ref="EpubLicense" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="PriceTypeDescription" />
 				<xs:element minOccurs="0" ref="PricePer" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="PriceCondition" />
@@ -5940,7 +6124,10 @@
 							<xs:element ref="PriceAmount" />
 							<xs:element ref="PriceCoded" />
 						</xs:choice>
-						<xs:element minOccurs="0" maxOccurs="unbounded" ref="Tax" />
+						<xs:choice minOccurs="0">
+							<xs:element maxOccurs="unbounded" ref="Tax" />
+							<xs:element ref="TaxExempt" />
+						</xs:choice>
 					</xs:sequence>
 					<xs:element ref="UnpricedItemType" />
 				</xs:choice>
@@ -5949,8 +6136,10 @@
 				<xs:element minOccurs="0" ref="CurrencyZone" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="ComparisonProductPrice" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="PriceDate" />
-				<xs:element minOccurs="0" ref="PrintedOnProduct" />
-				<xs:element minOccurs="0" ref="PositionOnProduct" />
+				<xs:sequence minOccurs="0">
+					<xs:element ref="PrintedOnProduct" />
+					<xs:element minOccurs="0" ref="PositionOnProduct" />
+				</xs:sequence>
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -6180,6 +6369,122 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="PriceConstraint">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="PriceConstraintType" />
+				<xs:element ref="PriceConstraintStatus" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="PriceConstraintLimit" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="PriceConstraint" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="priceconstraint" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PriceConstraintLimit">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Quantity" />
+				<xs:element ref="PriceConstraintUnit" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="PriceConstraintLimit" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="priceconstraintlimit" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PriceConstraintStatus">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List146">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="PriceConstraintStatus" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x530" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PriceConstraintType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List230">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="PriceConstraintType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x529" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PriceConstraintUnit">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List147">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="PriceConstraintUnit" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x531" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="PriceDate">
 		<xs:complexType>
 			<xs:sequence>
@@ -6270,6 +6575,30 @@
 						</xs:simpleType>
 					</xs:attribute>
 					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="PricePartDescription">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.NonEmptyString">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="PricePartDescription" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x535" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+					<xs:attributeGroup ref="languageAttribute" />
 				</xs:extension>
 			</xs:simpleContent>
 		</xs:complexType>
@@ -6386,122 +6715,6 @@
 					</xs:attribute>
 					<xs:attributeGroup ref="generalAttributes" />
 					<xs:attributeGroup ref="languageAttribute" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="PriceConstraint">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element ref="PriceConstraintType" />
-				<xs:element ref="PriceConstraintStatus" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="PriceConstraintLimit" />
-			</xs:sequence>
-			<xs:attribute name="refname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="PriceConstraint" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attribute name="shortname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="priceconstraint" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attributeGroup ref="generalAttributes" />
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="PriceConstraintLimit">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element ref="Quantity" />
-				<xs:element ref="PriceConstraintUnit" />
-			</xs:sequence>
-			<xs:attribute name="refname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="PriceConstraintLimit" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attribute name="shortname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="priceconstraintlimit" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attributeGroup ref="generalAttributes" />
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="PriceConstraintStatus">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List146">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="PriceConstraintStatus" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="x530" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="PriceConstraintType">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List230">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="PriceConstraintType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="x529" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="PriceConstraintUnit">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List147">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="PriceConstraintUnit" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="x531" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
 				</xs:extension>
 			</xs:simpleContent>
 		</xs:complexType>
@@ -7277,6 +7490,7 @@
 				<xs:element minOccurs="0" ref="ProductPackaging" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="ProductFormDescription" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="ProductContentType" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="Measure" />
 				<xs:choice>
 					<xs:sequence>
 						<xs:element ref="NumberOfItemsOfThisForm" />
@@ -7658,7 +7872,7 @@
 	<xs:element name="PublishingDetail">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:group ref="gp.publisher" />
+				<xs:group ref="gp.imprints_publishers" />
 				<xs:group ref="gp.publishing_status" />
 				<xs:group ref="gp.rights_restrictions" />
 			</xs:sequence>
@@ -7817,30 +8031,6 @@
 					<xs:attributeGroup ref="generalAttributes" />
 				</xs:extension>
 			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="ReviewRating">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element ref="Rating" />
-				<xs:element minOccurs="0" ref="RatingLimit" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="RatingUnits" />
-			</xs:sequence>
-			<xs:attribute name="refname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="ReviewRating" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attribute name="shortname">
-				<xs:simpleType>
-					<xs:restriction base="xs:token">
-						<xs:enumeration value="reviewrating" />
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="Rating">
@@ -8052,14 +8242,6 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
-	<xs:simpleType name="RegionCodeList">
-		<xs:restriction>
-			<xs:simpleType>
-				<xs:list itemType="List49" />
-			</xs:simpleType>
-			<xs:minLength value="1" />
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:element name="RegionsIncluded">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -8182,10 +8364,7 @@
 	</xs:element>
 	<xs:element name="RelatedMaterial">
 		<xs:complexType>
-			<xs:sequence>
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="RelatedWork" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="RelatedProduct" />
-			</xs:sequence>
+			<xs:group ref="gp.related_materials" />
 			<xs:attribute name="refname">
 				<xs:simpleType>
 					<xs:restriction base="xs:token">
@@ -8422,6 +8601,29 @@
 			</xs:complexContent>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="Reserved">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.PositiveInteger">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="Reserved" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x536" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="ResourceContentType">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -8634,29 +8836,6 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="ROWSalesRightsType">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List46">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="ROWSalesRightsType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="x456" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="ReturnsCode">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -8772,6 +8951,53 @@
 					</xs:attribute>
 					<xs:attributeGroup ref="generalAttributes" />
 					<xs:attributeGroup ref="languageAttribute" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="ReviewRating">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Rating" />
+				<xs:element minOccurs="0" ref="RatingLimit" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="RatingUnits" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="ReviewRating" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="reviewrating" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="ROWSalesRightsType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List46">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="ROWSalesRightsType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x456" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
 				</xs:extension>
 			</xs:simpleContent>
 		</xs:complexType>
@@ -9051,29 +9277,6 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="SenderIDType">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List44">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="SenderIDType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="m379" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="SenderIdentifier">
 		<xs:complexType>
 			<xs:sequence>
@@ -9096,6 +9299,29 @@
 				</xs:simpleType>
 			</xs:attribute>
 			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="SenderIDType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List44">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="SenderIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="m379" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="SenderName">
@@ -9261,6 +9487,29 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="StartTime">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.TimeOrDuration">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="StartTime" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x542" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="Stock">
 		<xs:complexType>
 			<xs:sequence>
@@ -9271,6 +9520,10 @@
 					<xs:sequence>
 						<xs:element ref="OnHand" />
 						<xs:element minOccurs="0" ref="Proximity" />
+						<xs:sequence minOccurs="0">
+							<xs:element ref="Reserved" />
+							<xs:element minOccurs="0" ref="Proximity" />
+						</xs:sequence>
 						<xs:sequence minOccurs="0">
 							<xs:element ref="OnOrder" />
 							<xs:element minOccurs="0" ref="Proximity" />
@@ -9888,6 +10141,130 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="SupplyContact">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="SupplyContactRole" />
+				<xs:choice>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" ref="SupplyContactIdentifier" />
+						<xs:element minOccurs="0" ref="SupplyContactName" />
+					</xs:sequence>
+					<xs:element ref="SupplyContactName" />
+				</xs:choice>
+				<xs:element minOccurs="0" ref="ContactName" />
+				<xs:element minOccurs="0" ref="EmailAddress" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="SupplyContact" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="supplycontact" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="SupplyContactIdentifier">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="SupplyContactIDType" />
+				<xs:element minOccurs="0" ref="IDTypeName" />
+				<xs:element ref="IDValue" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="SupplyContactIdentifier" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="supplycontactidentifier" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="SupplyContactIDType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List44">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="SupplyContactIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x538" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="SupplyContactName">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.NonEmptyString">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="SupplyContactName" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x539" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="SupplyContactRole">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List239">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="SupplyContactRole" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x537" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="SupplyDate">
 		<xs:complexType>
 			<xs:sequence>
@@ -9939,6 +10316,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element ref="Supplier" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="SupplyContact" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="SupplierOwnCoding" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="ReturnsConditions" />
 				<xs:element ref="ProductAvailability" />
@@ -9947,6 +10325,7 @@
 				<xs:element minOccurs="0" ref="NewSupplier" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="Stock" />
 				<xs:element minOccurs="0" ref="PackQuantity" />
+				<xs:element minOccurs="0" ref="PalletQuantity" />
 				<xs:sequence minOccurs="0">
 					<xs:element maxOccurs="2" ref="OrderQuantityMinimum" />
 					<xs:element minOccurs="0" ref="OrderQuantityMultiple" />
@@ -10005,6 +10384,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="ProductIdentifier" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="PricePartDescription" />
 				<xs:element minOccurs="0" ref="TaxType" />
 				<xs:element minOccurs="0" ref="TaxRateCode" />
 				<xs:choice>
@@ -10036,6 +10416,29 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="TaxableAmount">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.StrictPositiveDecimal">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="TaxableAmount" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x473" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="TaxAmount">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -10057,6 +10460,25 @@
 					<xs:attributeGroup ref="generalAttributes" />
 				</xs:extension>
 			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="TaxExempt">
+		<xs:complexType>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="TaxExempt" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="x546" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="TaxRateCode">
@@ -10097,29 +10519,6 @@
 						<xs:simpleType>
 							<xs:restriction base="xs:token">
 								<xs:enumeration value="x472" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="TaxableAmount">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="dt.StrictPositiveDecimal">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="TaxableAmount" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="x473" />
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>
@@ -10176,22 +10575,18 @@
 	</xs:element>
 	<xs:element name="Territory">
 		<xs:complexType>
-			<xs:sequence>
-				<xs:choice>
-					<xs:sequence>
-						<xs:element ref="CountriesIncluded" />
-						<xs:sequence minOccurs="0">
-							<xs:element ref="RegionsIncluded" />
-							<xs:element minOccurs="0" ref="CountriesExcluded" />
-						</xs:sequence>
-					</xs:sequence>
-					<xs:sequence>
-						<xs:element ref="RegionsIncluded" />
-						<xs:element minOccurs="0" ref="CountriesExcluded" />
-					</xs:sequence>
-				</xs:choice>
-				<xs:element minOccurs="0" ref="RegionsExcluded" />
-			</xs:sequence>
+			<xs:choice>
+				<xs:sequence>
+					<xs:element ref="CountriesIncluded" />
+					<xs:element minOccurs="0" ref="RegionsIncluded"/>
+					<xs:element minOccurs="0" ref="RegionsExcluded" />
+				</xs:sequence>
+				<xs:sequence>
+					<xs:element ref="RegionsIncluded" />
+					<xs:element minOccurs="0" ref="CountriesExcluded" />
+					<xs:element minOccurs="0" ref="RegionsExcluded" />
+				</xs:sequence>
+			</xs:choice>
 			<xs:attribute name="refname">
 				<xs:simpleType>
 					<xs:restriction base="xs:token">
@@ -10313,29 +10708,6 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="TextItemIDType">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List43">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="TextItemIDType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="b285" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="TextItemIdentifier">
 		<xs:complexType>
 			<xs:sequence>
@@ -10358,6 +10730,29 @@
 				</xs:simpleType>
 			</xs:attribute>
 			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="TextItemIDType">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List43">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="TextItemIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="b285" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="TextItemType">
@@ -10499,6 +10894,29 @@
 					<xs:attributeGroup ref="dateformatAttribute" />
 				</xs:extension>
 			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="TimeRun">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="StartTime" />
+				<xs:element minOccurs="0" ref="EndTime" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="TimeRun" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="timerun" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="TitleDetail">
@@ -10957,7 +11375,7 @@
 			<xs:sequence>
 				<xs:element minOccurs="0" ref="WebsiteRole" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="WebsiteDescription" />
-				<xs:element ref="WebsiteLink" />
+				<xs:element maxOccurs="unbounded" ref="WebsiteLink" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -11020,6 +11438,7 @@
 						</xs:simpleType>
 					</xs:attribute>
 					<xs:attributeGroup ref="generalAttributes" />
+					<xs:attributeGroup ref="languageAttribute" />
 				</xs:extension>
 			</xs:simpleContent>
 		</xs:complexType>
@@ -11217,7 +11636,7 @@
 			</xs:choice>
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.title">
+	<xs:group name="gp.titles">
 		<xs:sequence>
 			<xs:element maxOccurs="unbounded" ref="TitleDetail" />
 			<xs:sequence minOccurs="0">
@@ -11236,13 +11655,13 @@
 			<xs:element minOccurs="0" ref="NoContributor" />
 		</xs:choice>
 	</xs:group>
-	<xs:group name="gp.event">
+	<xs:group name="gp.events">
 		<xs:choice>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="Event" />
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="Conference" />
 		</xs:choice>
 	</xs:group>
-	<xs:group name="gp.edition">
+	<xs:group name="gp.editions">
 		<xs:sequence>
 			<xs:choice>
 				<xs:sequence>
@@ -11258,7 +11677,7 @@
 			<xs:element minOccurs="0" ref="ReligiousText" />
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.language">
+	<xs:group name="gp.languages">
 		<xs:sequence>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="Language" />
 		</xs:sequence>
@@ -11272,13 +11691,13 @@
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="AncillaryContent" />
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.subject">
+	<xs:group name="gp.subjects">
 		<xs:sequence>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="Subject" />
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="NameAsSubject" />
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.audience">
+	<xs:group name="gp.audiences">
 		<xs:sequence>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="AudienceCode" />
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="Audience" />
@@ -11294,12 +11713,18 @@
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="SupportingResource" />
 		</xs:sequence>
 	</xs:group>
+	<xs:group name="gp.related_materials">
+		<xs:sequence>
+			<xs:element minOccurs="0" maxOccurs="unbounded" ref="RelatedWork" />
+			<xs:element minOccurs="0" maxOccurs="unbounded" ref="RelatedProduct" />
+		</xs:sequence>
+	</xs:group>
 	<xs:group name="gp.prizes">
 		<xs:sequence>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="Prize" />
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.publisher">
+	<xs:group name="gp.imprints_publishers">
 		<xs:sequence>
 			<xs:choice>
 				<xs:sequence>
@@ -11333,6 +11758,22 @@
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="SalesRestriction" />
 		</xs:sequence>
 	</xs:group>
+	<xs:simpleType name="CountryCodeList">
+		<xs:restriction>
+			<xs:simpleType>
+				<xs:list itemType="List91" />
+			</xs:simpleType>
+			<xs:minLength value="1" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RegionCodeList">
+		<xs:restriction>
+			<xs:simpleType>
+				<xs:list itemType="List49" />
+			</xs:simpleType>
+			<xs:minLength value="1" />
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:simpleType name="dt.DateOrDateTime">
 		<xs:union>
 			<xs:simpleType>
@@ -11399,6 +11840,11 @@
 			<xs:pattern value="[12]\d\d\d" />
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="dt.TimeOrDuration">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{3}[0-5][0-9][0-5][0-9]([0-9]{2})?" />
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:simpleType name="dt.YearOrYearRange">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[12]\d\d\d(-[12]\d\d\d)?" />
@@ -11406,7 +11852,12 @@
 	</xs:simpleType>
 	<xs:simpleType name="dt.MultiLevelNumber">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="\d+(\.\d+)?" />
+			<xs:pattern value="\d+(\.\d+)*" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="dt.MultiLevelNumberOrHyphen">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="(\d+|-)(\.(\d+|-))*" />
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:attributeGroup name="releaseAttribute">
@@ -11419,12 +11870,12 @@
 		</xs:attribute>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="collationkeyAttribute">
-		<xs:attribute name="collationkey" type="xs:string" />
+		<xs:attribute name="collationkey" type="dt.NonEmptyString" />
 	</xs:attributeGroup>
 	<xs:attributeGroup name="generalAttributes">
 		<xs:attribute name="datestamp" type="dt.DateOrDateTime" />
 		<xs:attribute name="sourcetype" type="SourceTypeCode" />
-		<xs:attribute name="sourcename" />
+		<xs:attribute name="sourcename" type="dt.NonEmptyString" />
 	</xs:attributeGroup>
 	<xs:attributeGroup name="dateformatAttribute">
 		<xs:attribute name="dateformat" type="List55" />

--- a/src/onixcheck/schema/xsd3.0/ONIX_BookProduct_3.0_short.xsd
+++ b/src/onixcheck/schema/xsd3.0/ONIX_BookProduct_3.0_short.xsd
@@ -15,12 +15,12 @@
 	*          Recent revisions: Graham Bell         *
 	*                                                *
 	*                  Release 3.0                   *
-	*                   Revision 3                   *
-	*                Status: RELEASED                *
+	*                   Revision 6                   *
+	*               Status: RELEASED                 *
 	*            Release date: 2009-04-09            *
-	*              Revised: 2016-04-25               *
+	*              Revised: 2019-04-26               *
 	*                                                *
-	*             (c) 2000-2016 EDItEUR              *
+	*             (c) 2000-2019 EDItEUR              *
 	*             http://www.editeur.org/            *
 	*                                                *
 	**************************************************
@@ -58,6 +58,33 @@
 
 	SCHEMA REVISION HISTORY (IN REVERSE CHRONOLOGICAL ORDER)
 
+	2019-04-26: ONIX for Books 3.0 revision 6
+	            1. Added <Measure> within <ProductPart>
+	            2. Made <WebsiteLink> repeatable, added @language
+
+	2018-10-26: ONIX for Books 3.0 revision 5
+	            1. Added <AVItem> within <ContentItem>, as an alternative to <TextItem>
+	            2. Added <PalletQuantity> within <Supplier>
+	            3. Added <TaxExempt/> empty element
+	            4. Ensure Blocks 2, 3, 5 can be blank
+
+	2018-02-02: enforce 'if and only if' on <PositionOnProduct> in <Price>
+
+	2017-11-26: corrected content model for <InitialPrintRun> to match documentation
+
+	2017-10-26: ONIX for Books 3.0 revision 4
+	            1. Added <SupplyContact> within <SupplyDetail>
+	            2. Added <PricePartDescription> in <Tax>
+	            3. Added <EpubTechnicalProtection> and <EpubLicense> in <Price>
+	            4. Modified <CollectionSequenceNumber> to accept hyphen for unordered levels in numbering hierarchy
+	            5. Added <Reserved> within <Stock>
+	            6. Added <Language> in <ContentItem>
+	            7. Used gp.authorship in <Collection> and <ContentItem>
+
+	2017-10-19: Corrected regex for dt.MultiLevelNumber
+
+	2017-05-22: Simplified expression of data model for <Territory>
+
 	2016-04-25: ONIX for Books 3.0 revision 3
 	            1. added Event as near-synonym for Conference
 	               a. choose either elements labelled <Event…> OR <Conference…>, but cannot mix in one <Product> record
@@ -85,7 +112,7 @@
 	2016-01-24  1. enforce positive (>= 0), strict positive (> 0) or percentage (0..100) real numbers in various fields
 	            2. enforce positive (0, 1, 2…) or strict positive (1, 2, 3…) integers in various fields
 
-	               note these changes were included in 'strict' version of schema from 2015-01-24
+	               note these changes had been included in a 'strict' version of schema from 2015-01-24
 
 	2015-07-29: corrected Flow to dt.NonEmptyString in ConferenceName to match documentation
 
@@ -239,6 +266,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://ns.editeur.org/onix/3.0/short" xmlns="http://ns.editeur.org/onix/3.0/short">
 	<xs:include schemaLocation="ONIX_BookProduct_CodeLists.xsd" />
 	<xs:include schemaLocation="ONIX_XHTML_Subset.xsd" />
+
 	<xs:element name="addressee">
 		<xs:complexType>
 			<xs:sequence>
@@ -821,6 +849,124 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="x544">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.TimeOrDuration">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="AVDuration" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x544" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="avitem">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="x540" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="avitemidentifier" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="timerun" />
+				<xs:element minOccurs="0" ref="x544" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="AVItem" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="avitem" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="avitemidentifier">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="x541" />
+				<xs:element minOccurs="0" ref="b233" />
+				<xs:element ref="b244" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="AVItemIdentifier" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="avitemidentifier" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="x541">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List241">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="AVItemIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x541" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="x540">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List240">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="AVItemType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x540" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="barcode">
 		<xs:complexType>
 			<xs:sequence>
@@ -1194,9 +1340,9 @@
 						<xs:sequence minOccurs="0">
 							<xs:element maxOccurs="unbounded" ref="x432" />
 							<xs:element minOccurs="0" ref="x433" />
-						</xs:sequence>	
+						</xs:sequence>
 					</xs:sequence>
-					<xs:sequence minOccurs="0">
+					<xs:sequence>
 						<xs:element maxOccurs="unbounded" ref="x432" />
 						<xs:element minOccurs="0" ref="x433" />
 					</xs:sequence>
@@ -1300,10 +1446,7 @@
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="collectionidentifier" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="collectionsequence" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="titledetail" />
-				<xs:sequence minOccurs="0">
-					<xs:element maxOccurs="unbounded" ref="contributor" />
-					<xs:element minOccurs="0" maxOccurs="unbounded" ref="b049" />
-				</xs:sequence>
+				<xs:group ref="gp.authorship" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -1396,7 +1539,7 @@
 	<xs:element name="x481">
 		<xs:complexType>
 			<xs:simpleContent>
-				<xs:extension base="dt.MultiLevelNumber">
+				<xs:extension base="dt.MultiLevelNumberOrHyphen">
 					<xs:attribute name="refname">
 						<xs:simpleType>
 							<xs:restriction base="xs:token">
@@ -1706,7 +1849,7 @@
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="b052">
-		<xs:complexType mixed="true">
+		<xs:complexType>
 			<xs:simpleContent>
 				<xs:extension base="dt.NonEmptyString">
 					<xs:attribute name="refname">
@@ -1997,7 +2140,7 @@
 	<xs:element name="contentdetail">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element maxOccurs="unbounded" ref="contentitem" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="contentitem" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -2020,7 +2163,10 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element minOccurs="0" ref="b284" />
-				<xs:element ref="textitem" />
+				<xs:choice>
+					<xs:element ref="textitem" />
+					<xs:element ref="avitem" />
+				</xs:choice>
 				<xs:choice>
 					<xs:sequence>
 						<xs:element ref="b288" />
@@ -2032,14 +2178,11 @@
 						<xs:element maxOccurs="unbounded" ref="titledetail" />
 					</xs:sequence>
 				</xs:choice>
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="contributor" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="subject" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="nameassubject" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="textcontent" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="citedcontent" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="supportingresource" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="relatedwork" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="relatedproduct" />
+				<xs:group ref="gp.authorship" />
+				<xs:group ref="gp.languages" />
+				<xs:group ref="gp.subjects" />
+				<xs:group ref="gp.descriptions" />
+				<xs:group ref="gp.related_materials" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -2405,29 +2548,6 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="b392">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List44">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="CopyrightOwnerIDType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="b392" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="copyrightowneridentifier">
 		<xs:complexType>
 			<xs:sequence>
@@ -2450,6 +2570,29 @@
 				</xs:simpleType>
 			</xs:attribute>
 			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="b392">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List44">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="CopyrightOwnerIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="b392" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="copyrightstatement">
@@ -2889,14 +3032,14 @@
 			<xs:sequence>
 				<xs:group ref="gp.product_form" />
 				<xs:group ref="gp.collections" />
-				<xs:group ref="gp.title" />
+				<xs:group ref="gp.titles" />
 				<xs:group ref="gp.authorship" />
-				<xs:group ref="gp.event" />
-				<xs:group ref="gp.edition" />
-				<xs:group ref="gp.language" />
+				<xs:group ref="gp.events" />
+				<xs:group ref="gp.editions" />
+				<xs:group ref="gp.languages" />
 				<xs:group ref="gp.extents" />
-				<xs:group ref="gp.subject" />
-				<xs:group ref="gp.audience" />
+				<xs:group ref="gp.subjects" />
+				<xs:group ref="gp.audiences" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -3225,6 +3368,29 @@
 					</xs:attribute>
 					<xs:attributeGroup ref="generalAttributes" />
 					<xs:attributeGroup ref="dateformatAttribute" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="x543">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.TimeOrDuration">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="EndTime" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x543" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
 				</xs:extension>
 			</xs:simpleContent>
 		</xs:complexType>
@@ -4383,9 +4549,9 @@
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="k167">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="dt.NonEmptyString">
+		<xs:complexType mixed="true">
+			<xs:complexContent>
+				<xs:extension base="Flow">
 					<xs:attribute name="refname">
 						<xs:simpleType>
 							<xs:restriction base="xs:token">
@@ -4404,7 +4570,7 @@
 					<xs:attributeGroup ref="languageAttribute" />
 					<xs:attributeGroup ref="textformatAttribute" />
 				</xs:extension>
-			</xs:simpleContent>
+			</xs:complexContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="b040">
@@ -5726,6 +5892,29 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="x545">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.StrictPositiveInteger">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="PalletQuantity" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x545" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="x410">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -5927,7 +6116,9 @@
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="priceidentifier" />
 				<xs:element minOccurs="0" ref="x462" />
 				<xs:element minOccurs="0" ref="j261" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="x317" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="priceconstraint" />
+				<xs:element minOccurs="0" ref="epublicense" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="j262" />
 				<xs:element minOccurs="0" ref="j239" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="pricecondition" />
@@ -5942,7 +6133,10 @@
 							<xs:element ref="j151" />
 							<xs:element ref="pricecoded" />
 						</xs:choice>
-						<xs:element minOccurs="0" maxOccurs="unbounded" ref="tax" />
+						<xs:choice minOccurs="0">
+							<xs:element maxOccurs="unbounded" ref="tax" />
+							<xs:element ref="x546" />
+						</xs:choice>
 					</xs:sequence>
 					<xs:element ref="j192" />
 				</xs:choice>
@@ -5951,8 +6145,10 @@
 				<xs:element minOccurs="0" ref="x475" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="comparisonproductprice" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="pricedate" />
-				<xs:element minOccurs="0" ref="x301" />
-				<xs:element minOccurs="0" ref="x313" />
+				<xs:sequence minOccurs="0">
+					<xs:element ref="x301" />
+					<xs:element minOccurs="0" ref="x313" />
+				</xs:sequence>
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -6507,6 +6703,30 @@
 				</xs:extension>
 			</xs:simpleContent>
 		</xs:complexType>
+	</xs:element>
+	<xs:element name="x535">
+			<xs:complexType>
+				<xs:simpleContent>
+					<xs:extension base="dt.NonEmptyString">
+						<xs:attribute name="refname">
+							<xs:simpleType>
+								<xs:restriction base="xs:token">
+									<xs:enumeration value="PricePartDescription" />
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:attribute>
+						<xs:attribute name="shortname">
+							<xs:simpleType>
+								<xs:restriction base="xs:token">
+									<xs:enumeration value="x535" />
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:attribute>
+						<xs:attributeGroup ref="generalAttributes" />
+						<xs:attributeGroup ref="languageAttribute" />
+					</xs:extension>
+				</xs:simpleContent>
+			</xs:complexType>
 	</xs:element>
 	<xs:element name="x416">
 		<xs:complexType>
@@ -7279,6 +7499,7 @@
 				<xs:element minOccurs="0" ref="b225" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="b014" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="b385" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="measure" />
 				<xs:choice>
 					<xs:sequence>
 						<xs:element ref="x322" />
@@ -7660,7 +7881,7 @@
 	<xs:element name="publishingdetail">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:group ref="gp.publisher" />
+				<xs:group ref="gp.imprints_publishers" />
 				<xs:group ref="gp.publishing_status" />
 				<xs:group ref="gp.rights_restrictions" />
 			</xs:sequence>
@@ -7813,6 +8034,29 @@
 						<xs:simpleType>
 							<xs:restriction base="xs:token">
 								<xs:enumeration value="x505" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="x536">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.PositiveInteger">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="Reserved" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x536" />
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>
@@ -8184,10 +8428,7 @@
 	</xs:element>
 	<xs:element name="relatedmaterial">
 		<xs:complexType>
-			<xs:sequence>
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="relatedwork" />
-				<xs:element minOccurs="0" maxOccurs="unbounded" ref="relatedproduct" />
-			</xs:sequence>
+			<xs:group ref="gp.related_materials" />
 			<xs:attribute name="refname">
 				<xs:simpleType>
 					<xs:restriction base="xs:token">
@@ -9053,29 +9294,6 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="m379">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="List44">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="SenderIDType" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="m379" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:element name="senderidentifier">
 		<xs:complexType>
 			<xs:sequence>
@@ -9098,6 +9316,29 @@
 				</xs:simpleType>
 			</xs:attribute>
 			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="m379">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List44">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="SenderIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="m379" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="x298">
@@ -9263,6 +9504,29 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="x542">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.TimeOrDuration">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="StartTime" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x542" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="stock">
 		<xs:complexType>
 			<xs:sequence>
@@ -9273,6 +9537,10 @@
 					<xs:sequence>
 						<xs:element ref="j350" />
 						<xs:element minOccurs="0" ref="x502" />
+						<xs:sequence minOccurs="0">
+							<xs:element ref="x536" />
+							<xs:element minOccurs="0" ref="x502" />
+						</xs:sequence>
 						<xs:sequence minOccurs="0">
 							<xs:element ref="j351" />
 							<xs:element minOccurs="0" ref="x502" />
@@ -9890,6 +10158,130 @@
 			</xs:simpleContent>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="supplycontact">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="x537" />
+				<xs:choice>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" ref="supplycontactidentifier" />
+						<xs:element minOccurs="0" ref="x539" />
+					</xs:sequence>
+					<xs:element ref="x539" />
+				</xs:choice>
+				<xs:element minOccurs="0" ref="x299" />
+				<xs:element minOccurs="0" ref="j272" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="SupplyContact" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="supplycontact" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="supplycontactidentifier">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="x538" />
+				<xs:element minOccurs="0" ref="b233" />
+				<xs:element ref="b244" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="SupplyContactIdentifier" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="supplycontactidentifier" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="x538">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List44">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="SupplyContactIDType" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x538" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="x539">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.NonEmptyString">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="SupplyContactName" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x539" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="x537">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="List239">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="SupplyContactRole" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x537" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="supplydate">
 		<xs:complexType>
 			<xs:sequence>
@@ -9941,6 +10333,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element ref="supplier" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="supplycontact" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="supplierowncoding" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="returnsconditions" />
 				<xs:element ref="j396" />
@@ -9949,6 +10342,7 @@
 				<xs:element minOccurs="0" ref="newsupplier" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="stock" />
 				<xs:element minOccurs="0" ref="j145" />
+				<xs:element minOccurs="0" ref="x545" />
 				<xs:sequence minOccurs="0">
 					<xs:element maxOccurs="2" ref="x532" />
 					<xs:element minOccurs="0" ref="x533" />
@@ -10007,6 +10401,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="productidentifier" />
+				<xs:element minOccurs="0" maxOccurs="unbounded" ref="x535" />
 				<xs:element minOccurs="0" ref="x470" />
 				<xs:element minOccurs="0" ref="x471" />
 				<xs:choice>
@@ -10038,6 +10433,29 @@
 			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="x473">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="dt.StrictPositiveDecimal">
+					<xs:attribute name="refname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="TaxableAmount" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="shortname">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="x473" />
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attributeGroup ref="generalAttributes" />
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="x474">
 		<xs:complexType>
 			<xs:simpleContent>
@@ -10059,6 +10477,25 @@
 					<xs:attributeGroup ref="generalAttributes" />
 				</xs:extension>
 			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="x546">
+		<xs:complexType>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="TaxExempt" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="x546" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="x471">
@@ -10099,29 +10536,6 @@
 						<xs:simpleType>
 							<xs:restriction base="xs:token">
 								<xs:enumeration value="x472" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attributeGroup ref="generalAttributes" />
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="x473">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="dt.StrictPositiveDecimal">
-					<xs:attribute name="refname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="TaxableAmount" />
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="shortname">
-						<xs:simpleType>
-							<xs:restriction base="xs:token">
-								<xs:enumeration value="x473" />
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>
@@ -10178,22 +10592,18 @@
 	</xs:element>
 	<xs:element name="territory">
 		<xs:complexType>
-			<xs:sequence>
-				<xs:choice>
-					<xs:sequence>
-						<xs:element ref="x449" />
-						<xs:sequence minOccurs="0">
-							<xs:element ref="x450" />
-							<xs:element minOccurs="0" ref="x451" />
-						</xs:sequence>
-					</xs:sequence>
-					<xs:sequence>
-						<xs:element ref="x450" />
-						<xs:element minOccurs="0" ref="x451" />
-					</xs:sequence>
-				</xs:choice>
-				<xs:element minOccurs="0" ref="x452" />
-			</xs:sequence>
+			<xs:choice>
+				<xs:sequence>
+					<xs:element ref="x449" />
+					<xs:element minOccurs="0" ref="x450" />
+					<xs:element minOccurs="0" ref="x452" />
+				</xs:sequence>
+				<xs:sequence>
+					<xs:element ref="x450" />
+					<xs:element minOccurs="0" ref="x451" />
+					<xs:element minOccurs="0" ref="x452" />
+				</xs:sequence>
+			</xs:choice>
 			<xs:attribute name="refname">
 				<xs:simpleType>
 					<xs:restriction base="xs:token">
@@ -10501,6 +10911,29 @@
 					<xs:attributeGroup ref="dateformatAttribute" />
 				</xs:extension>
 			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="timerun">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="x542" />
+				<xs:element minOccurs="0" ref="x543" />
+			</xs:sequence>
+			<xs:attribute name="refname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="TimeRun" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="shortname">
+				<xs:simpleType>
+					<xs:restriction base="xs:token">
+						<xs:enumeration value="timerun" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="generalAttributes" />
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="titledetail">
@@ -10959,7 +11392,7 @@
 			<xs:sequence>
 				<xs:element minOccurs="0" ref="b367" />
 				<xs:element minOccurs="0" maxOccurs="unbounded" ref="b294" />
-				<xs:element ref="b295" />
+				<xs:element maxOccurs="unbounded" ref="b295" />
 			</xs:sequence>
 			<xs:attribute name="refname">
 				<xs:simpleType>
@@ -11022,6 +11455,7 @@
 						</xs:simpleType>
 					</xs:attribute>
 					<xs:attributeGroup ref="generalAttributes" />
+					<xs:attributeGroup ref="languageAttribute" />
 				</xs:extension>
 			</xs:simpleContent>
 		</xs:complexType>
@@ -11219,7 +11653,7 @@
 			</xs:choice>
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.title">
+	<xs:group name="gp.titles">
 		<xs:sequence>
 			<xs:element maxOccurs="unbounded" ref="titledetail" />
 			<xs:sequence minOccurs="0">
@@ -11238,13 +11672,13 @@
 			<xs:element minOccurs="0" ref="n339" />
 		</xs:choice>
 	</xs:group>
-	<xs:group name="gp.event">
+	<xs:group name="gp.events">
 		<xs:choice>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="event" />
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="conference" />
 		</xs:choice>
 	</xs:group>
-	<xs:group name="gp.edition">
+	<xs:group name="gp.editions">
 		<xs:sequence>
 			<xs:choice>
 				<xs:sequence>
@@ -11260,7 +11694,7 @@
 			<xs:element minOccurs="0" ref="religioustext" />
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.language">
+	<xs:group name="gp.languages">
 		<xs:sequence>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="language" />
 		</xs:sequence>
@@ -11274,13 +11708,13 @@
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="ancillarycontent" />
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.subject">
+	<xs:group name="gp.subjects">
 		<xs:sequence>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="subject" />
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="nameassubject" />
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.audience">
+	<xs:group name="gp.audiences">
 		<xs:sequence>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="b073" />
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="audience" />
@@ -11296,12 +11730,18 @@
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="supportingresource" />
 		</xs:sequence>
 	</xs:group>
+	<xs:group name="gp.related_materials">
+		<xs:sequence>
+			<xs:element minOccurs="0" maxOccurs="unbounded" ref="relatedwork" />
+			<xs:element minOccurs="0" maxOccurs="unbounded" ref="relatedproduct" />
+		</xs:sequence>
+	</xs:group>
 	<xs:group name="gp.prizes">
 		<xs:sequence>
 			<xs:element minOccurs="0" maxOccurs="unbounded" ref="prize" />
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="gp.publisher">
+	<xs:group name="gp.imprints_publishers">
 		<xs:sequence>
 			<xs:choice>
 				<xs:sequence>
@@ -11401,6 +11841,11 @@
 			<xs:pattern value="[12]\d\d\d" />
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="dt.TimeOrDuration">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{3}[0-5][0-9][0-5][0-9]([0-9]{2})?" />
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:simpleType name="dt.YearOrYearRange">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[12]\d\d\d(-[12]\d\d\d)?" />
@@ -11408,7 +11853,12 @@
 	</xs:simpleType>
 	<xs:simpleType name="dt.MultiLevelNumber">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="\d+(\.\d+)?" />
+			<xs:pattern value="\d+(\.\d+)*" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="dt.MultiLevelNumberOrHyphen">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="(\d+|-)(\.(\d+|-))*" />
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:attributeGroup name="releaseAttribute">
@@ -11421,12 +11871,12 @@
 		</xs:attribute>
 	</xs:attributeGroup>
 	<xs:attributeGroup name="collationkeyAttribute">
-		<xs:attribute name="collationkey" type="xs:string" />
+		<xs:attribute name="collationkey" type="dt.NonEmptyString" />
 	</xs:attributeGroup>
 	<xs:attributeGroup name="generalAttributes">
 		<xs:attribute name="datestamp" type="dt.DateOrDateTime" />
 		<xs:attribute name="sourcetype" type="SourceTypeCode" />
-		<xs:attribute name="sourcename" />
+		<xs:attribute name="sourcename" type="dt.NonEmptyString" />
 	</xs:attributeGroup>
 	<xs:attributeGroup name="dateformatAttribute">
 		<xs:attribute name="dateformat" type="List55" />

--- a/src/onixcheck/schema/xsd3.0/ONIX_BookProduct_CodeLists.xsd
+++ b/src/onixcheck/schema/xsd3.0/ONIX_BookProduct_CodeLists.xsd
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
+
 	**************************************************
 	*                                                *
 	*               ONIX INTERNATIONAL               *
@@ -9,16 +10,16 @@
 	*           CODE LIST DATA TYPES MODULE          *
 	*               XML SCHEMA VERSION               *
 	*                                                *
-	*                    ISSUE: 34                   *
+	*                    ISSUE: 45                   *
 	*                                                *
 	*                 Status: RELEASED               *
-	*            Release date: 2016-07-25            *
+	*            Release date: 2019-04-03            *
 	*                                                *
 	*  Orig filename ONIX_BookProduct_CodeLists.XSD  *
 	*                                                *
 	*          Original author: Francis Cave         *
 	*                                                *
-	*              (c) 2003-2016 EDItEUR             *
+	*              (c) 2003-2019 EDItEUR             *
 	*             http://www.editeur.org/            *
 	*                                                *
 	**************************************************
@@ -58,17 +59,50 @@
 
 	MODULE REVISION HISTORY (IN REVERSE CHRONOLOGICAL ORDER)
 
+	2019-04-03: Module for public release based upon the ONIX International
+	            Code lists Issue 45 (April 2019)
+
+	2019-01-16: Module for public release based upon the ONIX International
+	            Code lists Issue 44 (January 2019)
+
+	2018-10-29: Module for public release based upon the ONIX International
+	            Code lists Issue 43 (October 2018)
+
+	2018-07-09: Module for public release based upon the ONIX International
+	            Code lists Issue 42 (July 2018)
+
+	2018-04-16: Module for public release based upon the ONIX International
+	            Code lists Issue 41 (April 2018)
+
+	2018-01-23: Module for public release based upon the ONIX International
+	            Code lists Issue 40 (January 2018)
+
+	2017-10-19: Module for public release based upon the ONIX International
+	            Code lists Issue 39 (October 2017)
+
+	2017-07-10: Module for public release based upon the ONIX International
+	            Code lists Issue 38 (July 2017)
+
+	2017-04-03: Module for public release based upon the ONIX International
+	            Code lists Issue 37 (April 2017)
+
+	2017-01-16: Module for public release based upon the ONIX International
+	            Code lists Issue 36 (January 2017)
+
+	2016-10-25: Module for public release based upon the ONIX International
+	            Code lists Issue 35 (October 2016)
+
 	2016-07-25: Module for public release based upon the ONIX International
-	         Code lists Issue 34 (July 2016)
+	            Code lists Issue 34 (July 2016)
 
 	2016-04-25: Module for public release based upon the ONIX International
-	         Code lists Issue 33 (April 2016)
+	            Code lists Issue 33 (April 2016)
 
 	2016-01-23: Module for public release based upon the ONIX International
-	         Code lists Issue 32 (January 2016)
+	            Code lists Issue 32 (January 2016)
 
 	2015-11-02: Module for public release based upon the ONIX International
-	         Code lists Issue 31 (November 2015)
+	            Code lists Issue 31 (November 2015)
 
 	2015-07-29: Module for public release based upon the ONIX International
 	            Code lists Issue 30 (July 2015)
@@ -168,11 +202,12 @@
 
 	2003-12-30: First Draft Module based upon the ONIX International
 	            Code Lists Issue 2 (December 2003)
+
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<xs:simpleType name="List1">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 1">Notification or update type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 1">Notification or update type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -190,19 +225,19 @@
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>Notification confirmed on publication</xs:documentation>
-					<xs:documentation>Use for a complete record issued to confirm advance information at or just before actual publication date; or for a complete record issued at any later date</xs:documentation>
+					<xs:documentation>Use for a complete record issued to confirm advance information at or just before actual publication date, usually from the book-in-hand, or for a complete record issued at any later date</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="04">
 				<xs:annotation>
 					<xs:documentation>Update (partial)</xs:documentation>
-					<xs:documentation>In ONIX 3.0 only, use when sending a ‘block update’ record. In previous ONIX releases, ONIX updating has generally been by complete record replacement using code 03, and code 04 is not used</xs:documentation>
+					<xs:documentation>In ONIX 3.0 only, use when sending a ‘block update’ record. A block update implies using the supplied block(s) to update the existing record for the product, replacing only the blocks included in the block update, and leaving other blocks unchanged – for example, replacing old information from Blocks 4 and 6 with the newly-received data while retailing information from Blocks 1–3 and 5 untouched. In previous ONIX releases, and for ONIX 3.0 using other notification types, updating is by replacing the complete record with the newly-received data</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
 				<xs:annotation>
 					<xs:documentation>Delete</xs:documentation>
-					<xs:documentation>Use when sending an instruction to delete a record which was previously issued. Note that a Delete instruction should NOT be used when a product is cancelled, put out of print, or otherwise withdrawn from sale: this should be handled as a change of Publishing status, leaving the receiver to decide whether to retain or delete the record. A Delete instruction is only used when there is a particular reason to withdraw a record completely, eg because it was issued in error</xs:documentation>
+					<xs:documentation>Use when sending an instruction to delete a record which was previously issued. Note that a Delete instruction should NOT be used when a product is cancelled, put out of print, or otherwise withdrawn from sale: this should be handled as a change of Publishing status, leaving the receiver to decide whether to retain or delete the record. A Delete instruction is used ONLY when there is a particular reason to withdraw a record completely, eg because it was issued in error</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="08">
@@ -217,34 +252,16 @@
 					<xs:documentation>Notice of acquisition of a product, by one publisher from another: sent by the acquiring publisher</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="12">
-				<xs:annotation>
-					<xs:documentation>Update – SupplyDetail only</xs:documentation>
-					<xs:documentation>ONIX Books 2.1 supply update – &lt;SupplyDetail&gt; only (not used in ONIX 3.0)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="13">
-				<xs:annotation>
-					<xs:documentation>Update – MarketRepresentation only</xs:documentation>
-					<xs:documentation>ONIX Books 2.1 supply update – &lt;MarketRepresentation&gt; only (not used in ONIX 3.0)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="14">
-				<xs:annotation>
-					<xs:documentation>Update – SupplyDetail and MarketRepresentation</xs:documentation>
-					<xs:documentation>ONIX Books 2.1 supply update – both &lt;SupplyDetail&gt; and &lt;MarketRepresentation&gt; (not used in ONIX 3.0)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
 			<xs:enumeration value="88">
 				<xs:annotation>
 					<xs:documentation>Test update (Partial)</xs:documentation>
-					<xs:documentation>ONIX 3.0 only. Record may be processed for test purposes, but data should be discarded. Sender must ensure the &lt;RecordReference&gt; matches a previously-sent Test record</xs:documentation>
+					<xs:documentation>ONIX 3.0 only. Record may be processed for test purposes, but data should be discarded when testing is complete. Sender must ensure the &lt;RecordReference&gt; matches a previously-sent Test record</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="89">
 				<xs:annotation>
 					<xs:documentation>Test record</xs:documentation>
-					<xs:documentation>Record may be processed for test purposes, but data should be discarded. Sender must ensure the &lt;RecordReference&gt; does not match any previously-sent live product record</xs:documentation>
+					<xs:documentation>Record may be processed for test purposes, but data should be discarded when testing is complete. Sender must ensure the &lt;RecordReference&gt; does not match any previously-sent live product record</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -256,45 +273,45 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
 				<xs:annotation>
-					<xs:documentation>Single-item retail product</xs:documentation>
+					<xs:documentation>Single-component retail product</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="10">
 				<xs:annotation>
-					<xs:documentation>Multiple-item retail product</xs:documentation>
-					<xs:documentation>Multiple-item product retailed as a whole</xs:documentation>
+					<xs:documentation>Multiple-component retail product</xs:documentation>
+					<xs:documentation>Multiple-component product retailed as a whole</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="11">
 				<xs:annotation>
 					<xs:documentation>Multiple-item collection, retailed as separate parts</xs:documentation>
-					<xs:documentation>Used when an ONIX record is required for a collection-as-a-whole, even though it is not currently retailed as such</xs:documentation>
+					<xs:documentation>Used only when an ONIX record is required for a collection-as-a-whole, even though it is not currently retailed as such</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="20">
 				<xs:annotation>
 					<xs:documentation>Trade-only product</xs:documentation>
-					<xs:documentation>Product not for retail, and not carrying retail items, eg empty dumpbin, empty counterpack, promotional material</xs:documentation>
+					<xs:documentation>Product available to the book trade, but not for retail sale, and not carrying retail items, eg empty dumpbin, empty counterpack, promotional material</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="30">
 				<xs:annotation>
-					<xs:documentation>Multiple-item trade pack</xs:documentation>
-					<xs:documentation>Carrying multiple copies for retailing as separate items, eg shrink-wrapped trade pack, filled dumpbin, filled counterpack</xs:documentation>
+					<xs:documentation>Multiple-item trade-only pack</xs:documentation>
+					<xs:documentation>Product available to the book trade, but not for general retail sale as a whole. It carries multiple components for retailing as separate items, eg shrink-wrapped trade pack, filled dumpbin, filled counterpack</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="31">
 				<xs:annotation>
 					<xs:documentation>Multiple-item pack</xs:documentation>
-					<xs:documentation>Carrying multiple copies, primarily for retailing as separate items. The pack may be split and retailed as separate items OR retailed as a single item. Use instead of Multiple item trade pack (code 30) only if the data provider specifically wishes to make explicit that the pack may optionally be retailed as a whole</xs:documentation>
+					<xs:documentation>Carrying multiple components, primarily for retailing as separate items. The pack may be split and retailed as separate items OR retailed as a single item. Use instead of Multiple-item trade-only pack (code 30) if the data provider specifically wishes to make explicit that the pack may optionally be retailed as a whole</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List3">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 3">Record source type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 3">Record source type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -330,7 +347,7 @@
 			<xs:enumeration value="05">
 				<xs:annotation>
 					<xs:documentation>Library bookseller</xs:documentation>
-					<xs:documentation>Bookseller selling to libraries (including academic libraries)</xs:documentation>
+					<xs:documentation>Library supplier. Bookseller selling to libraries (including academic libraries)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
@@ -342,13 +359,13 @@
 			<xs:enumeration value="07">
 				<xs:annotation>
 					<xs:documentation>Publisher’s conversion service provider</xs:documentation>
-					<xs:documentation>Downstream provider of e-publication format conversion service (who might also be a distributor or retailer of the converted e-publication), supplying metadata on behalf of the publisher. The assigned ISBN is taken from the publisher’s ISBN prefix</xs:documentation>
+					<xs:documentation>Downstream provider of e-publication format conversion services (who might also be a distributor or retailer of the converted e-publication), supplying metadata on behalf of the publisher. The assigned ISBN is taken from the publisher’s ISBN prefix</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Conversion service provider</xs:documentation>
-					<xs:documentation>Downstream provider of e-publication format conversion service (who might also be a distributor or retailer of the converted e-publication), supplying metadata on behalf of the publisher. The assigned ISBN is taken from the service provider’s prefix (whether or not the service provider dedicates that prefix to a particular publisher)</xs:documentation>
+					<xs:documentation>Downstream provider of e-publication format conversion services (who might also be a distributor or retailer of the converted e-publication), supplying metadata on behalf of the publisher. The assigned ISBN is taken from the service provider’s prefix (whether or not the service provider dedicates that prefix to a particular publisher)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
@@ -375,65 +392,71 @@
 					<xs:documentation>Bookseller selling primarily to educational institutions</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Library</xs:documentation>
+					<xs:documentation>Library service providing enhanced metadata to publishers or other parties</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List5">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 5">Product identifier type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 5">Product identifier type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Proprietary</xs:documentation>
-					<xs:documentation>For example, a publisher’s or wholesaler’s product number. Note that &lt;IDTypeName&gt; is required with proprietary identifiers</xs:documentation>
+					<xs:documentation>For example, a publisher’s or wholesaler’s product number or SKU. Note that &lt;IDTypeName&gt; is required with proprietary identifiers</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>ISBN-10</xs:documentation>
-					<xs:documentation>International Standard Book Number, pre-2007, unhyphenated (10 characters) – now DEPRECATED in ONIX for Books, except where providing historical information for compatibility with legacy systems. It should only be used in relation to products published before 2007 – when ISBN-13 superseded it – and should never be used as the ONLY identifier (it should always be accompanied by the correct GTIN-13 / ISBN-13)</xs:documentation>
+					<xs:documentation>International Standard Book Number, pre-2007 (10 digits, or 9 digits plus X, without spaces or hyphens) – now DEPRECATED in ONIX for Books, except where providing historical information for compatibility with legacy systems. It should only be used in relation to products published before 2007 – when ISBN-13 superseded it – and should never be used as the ONLY identifier (it should always be accompanied by the correct GTIN-13 / ISBN-13)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>GTIN-13</xs:documentation>
-					<xs:documentation>GS1 Global Trade Item Number, formerly known as EAN article number (13 digits)</xs:documentation>
+					<xs:documentation>GS1 Global Trade Item Number, formerly known as EAN article number (13 digits, without spaces or hyphens)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="04">
 				<xs:annotation>
 					<xs:documentation>UPC</xs:documentation>
-					<xs:documentation>UPC product number (12 digits)</xs:documentation>
+					<xs:documentation>UPC product number (12 digits, without spaces or hyphens)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
 				<xs:annotation>
 					<xs:documentation>ISMN-10</xs:documentation>
-					<xs:documentation>International Standard Music Number (M plus nine digits). Pre-2008 – now DEPRECATED in ONIX for Books, except where providing historical information for compatibility with legacy systems. It should only be used in relation to products published before 2008 – when ISMN-13 superseded it – and should never be used as the ONLY identifier (it should always be accompanied by the correct ISMN-13)</xs:documentation>
+					<xs:documentation>International Standard Music Number, pre-2008 (M plus nine digits, without spaces or hyphens) – now DEPRECATED in ONIX for Books, except where providing historical information for compatibility with legacy systems. It should only be used in relation to products published before 2008 – when ISMN-13 superseded it – and should never be used as the ONLY identifier (it should always be accompanied by the correct GTIN-12 / ISMN-13)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
 				<xs:annotation>
 					<xs:documentation>DOI</xs:documentation>
-					<xs:documentation>Digital Object Identifier (variable length and character set)</xs:documentation>
+					<xs:documentation>Digital Object Identifier (variable length and character set beginning ‘10.’, and without https://doi.org/ or the older http://dx.doi.org/)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="13">
 				<xs:annotation>
 					<xs:documentation>LCCN</xs:documentation>
-					<xs:documentation>Library of Congress Control Number (12 characters, alphanumeric)</xs:documentation>
+					<xs:documentation>Library of Congress Control Number in normalized form (up to 12 characters, alphanumeric)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="14">
 				<xs:annotation>
 					<xs:documentation>GTIN-14</xs:documentation>
-					<xs:documentation>GS1 Global Trade Item Number (14 digits)</xs:documentation>
+					<xs:documentation>GS1 Global Trade Item Number (14 digits, without spaces or hyphens)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="15">
 				<xs:annotation>
 					<xs:documentation>ISBN-13</xs:documentation>
-					<xs:documentation>International Standard Book Number, from 2007, unhyphenated (13 digits starting 978 or 9791–9799)</xs:documentation>
+					<xs:documentation>International Standard Book Number, from 2007 (13 digits starting 978 or 9791–9799, without spaces or hypens)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="17">
@@ -457,19 +480,19 @@
 			<xs:enumeration value="24">
 				<xs:annotation>
 					<xs:documentation>Co-publisher’s ISBN-13</xs:documentation>
-					<xs:documentation>An ISBN-13 assigned by a co-publisher. The ‘main’ ISBN sent with ID type code 03 and/or 15 should always be the ISBN that is used for ordering from the supplier identified in Supply Detail. However, ISBN rules allow a co-published title to carry more than one ISBN. The co-publisher should be identified in an instance of the &lt;Publisher&gt; composite, with the applicable &lt;PublishingRole&gt; code</xs:documentation>
+					<xs:documentation>An ISBN-13 assigned by a co-publisher. The ‘main’ ISBN sent with &lt;ProductIDType&gt; codes 03 and/or 15 should always be the ISBN that is used for ordering from the supplier identified in &lt;SupplyDetail&gt;. However, ISBN rules allow a co-published title to carry more than one ISBN. The co-publisher should be identified in an instance of the &lt;Publisher&gt; composite, with the applicable &lt;PublishingRole&gt; code</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="25">
 				<xs:annotation>
 					<xs:documentation>ISMN-13</xs:documentation>
-					<xs:documentation>International Standard Music Number, from 2008 (13-digit number starting 9790)</xs:documentation>
+					<xs:documentation>International Standard Music Number, from 2008 (13-digit number starting 9790, without spaces or hyphens)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="26">
 				<xs:annotation>
 					<xs:documentation>ISBN-A</xs:documentation>
-					<xs:documentation>Actionable ISBN, in fact a special DOI incorporating the ISBN-13 within the DOI syntax. Begins ‘10.978.’ or ‘10.979.’ and includes a / character between the registrant element (publisher prefix) and publication element of the ISBN, eg 10.978.000/1234567. Note the ISBN-A should always be accompanied by the ISBN itself, using codes 03 and/or 15</xs:documentation>
+					<xs:documentation>Actionable ISBN, in fact a special DOI incorporating the ISBN-13 within the DOI syntax. Begins ‘10.978.’ or ‘10.979.’ and includes a / character between the registrant element (publisher prefix) and publication element of the ISBN, eg 10.978.000/1234567. Note the ISBN-A should always be accompanied by the ISBN itself, using &lt;ProductIDType&gt; codes 03 and/or 15</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="27">
@@ -499,1325 +522,32 @@
 			<xs:enumeration value="31">
 				<xs:annotation>
 					<xs:documentation>BNF Control number</xs:documentation>
-					<xs:documentation>Numéro de la notice BNF</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List6">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 6">Barcode indicator</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="00">
-				<xs:annotation>
-					<xs:documentation>Not barcoded</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>Barcoded, scheme unspecified</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>EAN13</xs:documentation>
-					<xs:documentation>Position unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 (US dollar price encoded)</xs:documentation>
-					<xs:documentation>Position unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>UPC12</xs:documentation>
-					<xs:documentation>Type and position unspecified. DEPRECATED: if possible, use more specific values below</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>UPC12+5</xs:documentation>
-					<xs:documentation>Type and position unspecified. DEPRECATED: if possible, use more specific values below</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>UPC12 (item-specific)</xs:documentation>
-					<xs:documentation>AKA item/price: position unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="07">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (item-specific)</xs:documentation>
-					<xs:documentation>AKA item/price: position unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="08">
-				<xs:annotation>
-					<xs:documentation>UPC12 (price-point)</xs:documentation>
-					<xs:documentation>AKA price/item: position unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="09">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (price-point)</xs:documentation>
-					<xs:documentation>AKA price/item: position unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="10">
-				<xs:annotation>
-					<xs:documentation>EAN13 on cover 4</xs:documentation>
-					<xs:documentation>‘Cover 4’ is defined as the back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="11">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on cover 4 (US dollar price encoded)</xs:documentation>
-					<xs:documentation>‘Cover 4’ is defined as the back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="12">
-				<xs:annotation>
-					<xs:documentation>UPC12 (item-specific) on cover 4</xs:documentation>
-					<xs:documentation>AKA item/price; ‘cover 4’ is defined as the back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="13">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (item-specific) on cover 4</xs:documentation>
-					<xs:documentation>AKA item/price; ‘cover 4’ is defined as the back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="14">
-				<xs:annotation>
-					<xs:documentation>UPC12 (price-point) on cover 4</xs:documentation>
-					<xs:documentation>AKA price/item; ‘cover 4’ is defined as the back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="15">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (price-point) on cover 4</xs:documentation>
-					<xs:documentation>AKA price/item; ‘cover 4’ is defined as the back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="16">
-				<xs:annotation>
-					<xs:documentation>EAN13 on cover 3</xs:documentation>
-					<xs:documentation>‘Cover 3’ is defined as the inside back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="17">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on cover 3 (US dollar price encoded)</xs:documentation>
-					<xs:documentation>‘Cover 3’ is defined as the inside back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="18">
-				<xs:annotation>
-					<xs:documentation>UPC12 (item-specific) on cover 3</xs:documentation>
-					<xs:documentation>AKA item/price; ‘cover 3’ is defined as the inside back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="19">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (item-specific) on cover 3</xs:documentation>
-					<xs:documentation>AKA item/price; ‘cover 3’ is defined as the inside back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="20">
-				<xs:annotation>
-					<xs:documentation>UPC12 (price-point) on cover 3</xs:documentation>
-					<xs:documentation>AKA price/item; ‘cover 3’ is defined as the inside back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="21">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (price-point) on cover 3</xs:documentation>
-					<xs:documentation>AKA price/item; ‘cover 3’ is defined as the inside back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="22">
-				<xs:annotation>
-					<xs:documentation>EAN13 on cover 2</xs:documentation>
-					<xs:documentation>‘Cover 2’ is defined as the inside front cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="23">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on cover 2 (US dollar price encoded)</xs:documentation>
-					<xs:documentation>‘Cover 2’ is defined as the inside front cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="24">
-				<xs:annotation>
-					<xs:documentation>UPC12 (item-specific) on cover 2</xs:documentation>
-					<xs:documentation>AKA item/price; ‘cover 2’ is defined as the inside front cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="25">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (item-specific) on cover 2</xs:documentation>
-					<xs:documentation>AKA item/price; ‘cover 2’ is defined as the inside front cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="26">
-				<xs:annotation>
-					<xs:documentation>UPC12 (price-point) on cover 2</xs:documentation>
-					<xs:documentation>AKA price/item; ‘cover 2’ is defined as the inside front cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="27">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (price-point) on cover 2</xs:documentation>
-					<xs:documentation>AKA price/item; ‘cover 2’ is defined as the inside front cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="28">
-				<xs:annotation>
-					<xs:documentation>EAN13 on box</xs:documentation>
-					<xs:documentation>To be used only on boxed products</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="29">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on box (US dollar price encoded)</xs:documentation>
-					<xs:documentation>To be used only on boxed products</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="30">
-				<xs:annotation>
-					<xs:documentation>UPC12 (item-specific) on box</xs:documentation>
-					<xs:documentation>AKA item/price; to be used only on boxed products</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="31">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (item-specific) on box</xs:documentation>
-					<xs:documentation>AKA item/price; to be used only on boxed products</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="32">
-				<xs:annotation>
-					<xs:documentation>UPC12 (price-point) on box</xs:documentation>
-					<xs:documentation>AKA price/item; to be used only on boxed products</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="33">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (price-point) on box</xs:documentation>
-					<xs:documentation>AKA price/item; to be used only on boxed products</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="34">
-				<xs:annotation>
-					<xs:documentation>EAN13 on tag</xs:documentation>
-					<xs:documentation>To be used only on products fitted with hanging tags</xs:documentation>
+					<xs:documentation>Numéro de la notice bibliographique BNF</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="35">
 				<xs:annotation>
-					<xs:documentation>EAN13+5 on tag (US dollar price encoded)</xs:documentation>
-					<xs:documentation>To be used only on products fitted with hanging tags</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="36">
-				<xs:annotation>
-					<xs:documentation>UPC12 (item-specific) on tag</xs:documentation>
-					<xs:documentation>AKA item/price; to be used only on products fitted with hanging tags</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="37">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (item-specific) on tag</xs:documentation>
-					<xs:documentation>AKA item/price; to be used only on products fitted with hanging tags</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="38">
-				<xs:annotation>
-					<xs:documentation>UPC12 (price-point) on tag</xs:documentation>
-					<xs:documentation>AKA price/item; to be used only on products fitted with hanging tags</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="39">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (price-point) on tag</xs:documentation>
-					<xs:documentation>AKA price/item; to be used only on products fitted with hanging tags</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="40">
-				<xs:annotation>
-					<xs:documentation>EAN13 on bottom</xs:documentation>
-					<xs:documentation>Not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="41">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on bottom (US dollar price encoded)</xs:documentation>
-					<xs:documentation>Not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="42">
-				<xs:annotation>
-					<xs:documentation>UPC12 (item-specific) on bottom</xs:documentation>
-					<xs:documentation>AKA item/price; not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="43">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (item-specific) on bottom</xs:documentation>
-					<xs:documentation>AKA item/price; not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="44">
-				<xs:annotation>
-					<xs:documentation>UPC12 (price-point) on bottom</xs:documentation>
-					<xs:documentation>AKA price/item; not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="45">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (price-point) on bottom</xs:documentation>
-					<xs:documentation>AKA price/item; not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="46">
-				<xs:annotation>
-					<xs:documentation>EAN13 on back</xs:documentation>
-					<xs:documentation>Not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="47">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on back (US dollar price encoded)</xs:documentation>
-					<xs:documentation>Not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="48">
-				<xs:annotation>
-					<xs:documentation>UPC12 (item-specific) on back</xs:documentation>
-					<xs:documentation>AKA item/price; not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="49">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (item-specific) on back</xs:documentation>
-					<xs:documentation>AKA item/price; not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="50">
-				<xs:annotation>
-					<xs:documentation>UPC12 (price-point) on back</xs:documentation>
-					<xs:documentation>AKA price/item; not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="51">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (price-point) on back</xs:documentation>
-					<xs:documentation>AKA price/item; not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="52">
-				<xs:annotation>
-					<xs:documentation>EAN13 on outer sleeve/back</xs:documentation>
-					<xs:documentation>To be used only on products packaged in outer sleeves</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="53">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on outer sleeve/back (US dollar price encoded)</xs:documentation>
-					<xs:documentation>To be used only on products packaged in outer sleeves</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="54">
-				<xs:annotation>
-					<xs:documentation>UPC12 (item-specific) on outer sleeve/back</xs:documentation>
-					<xs:documentation>AKA item/price; to be used only on products packaged in outer sleeves</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="55">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (item-specific) on outer sleeve/back</xs:documentation>
-					<xs:documentation>AKA item/price; to be used only on products packaged in outer sleeves</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="56">
-				<xs:annotation>
-					<xs:documentation>UPC12 (price-point) on outer sleeve/back</xs:documentation>
-					<xs:documentation>AKA price/item; to be used only on products packaged in outer sleeves</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="57">
-				<xs:annotation>
-					<xs:documentation>UPC12+5 (price-point) on outer sleeve/back</xs:documentation>
-					<xs:documentation>AKA price/item; to be used only on products packaged in outer sleeves</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="58">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 (no price encoded)</xs:documentation>
-					<xs:documentation>Position unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="59">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on cover 4 (no price encoded)</xs:documentation>
-					<xs:documentation>‘Cover 4’ is defined as the back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="60">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on cover 3 (no price encoded)</xs:documentation>
-					<xs:documentation>‘Cover 3’ is defined as the inside back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="61">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on cover 2 (no price encoded)</xs:documentation>
-					<xs:documentation>‘Cover 2’ is defined as the inside front cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="62">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on box (no price encoded)</xs:documentation>
-					<xs:documentation>To be used only on boxed products</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="63">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on tag (no price encoded)</xs:documentation>
-					<xs:documentation>To be used only on products fitted with hanging tags</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="64">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on bottom (no price encoded)</xs:documentation>
-					<xs:documentation>Not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="65">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on back (no price encoded)</xs:documentation>
-					<xs:documentation>Not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="66">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on outer sleeve/back (no price encoded)</xs:documentation>
-					<xs:documentation>To be used only on products packaged in outer sleeves</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="67">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 (CAN dollar price encoded)</xs:documentation>
-					<xs:documentation>Position unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="68">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on cover 4 (CAN dollar price encoded)</xs:documentation>
-					<xs:documentation>‘Cover 4’ is defined as the back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="69">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on cover 3 (CAN dollar price encoded)</xs:documentation>
-					<xs:documentation>‘Cover 3’ is defined as the inside back cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="70">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on cover 2 (CAN dollar price encoded)</xs:documentation>
-					<xs:documentation>‘Cover 2’ is defined as the inside front cover of a book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="71">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on box (CAN dollar price encoded)</xs:documentation>
-					<xs:documentation>To be used only on boxed products</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="72">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on tag (CAN dollar price encoded)</xs:documentation>
-					<xs:documentation>To be used only on products fitted with hanging tags</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="73">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on bottom (CAN dollar price encoded)</xs:documentation>
-					<xs:documentation>Not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="74">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on back (CAN dollar price encoded)</xs:documentation>
-					<xs:documentation>Not be used on books unless they are contained within outer packaging</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="75">
-				<xs:annotation>
-					<xs:documentation>EAN13+5 on outer sleeve/back (CAN dollar price encoded)</xs:documentation>
-					<xs:documentation>To be used only on products packaged in outer sleeves</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List7">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 7">Product form code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="00">
-				<xs:annotation>
-					<xs:documentation>Undefined</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AA">
-				<xs:annotation>
-					<xs:documentation>Audio</xs:documentation>
-					<xs:documentation>Audio recording – detail unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AB">
-				<xs:annotation>
-					<xs:documentation>Audio cassette</xs:documentation>
-					<xs:documentation>Audio cassette (analogue)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AC">
-				<xs:annotation>
-					<xs:documentation>CD-Audio</xs:documentation>
-					<xs:documentation>Audio compact disc, in any recording format: use for ‘red book’ (conventional audio CD) and SACD, and use coding in Product Form Detail to specify the format, if required</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AD">
-				<xs:annotation>
-					<xs:documentation>DAT</xs:documentation>
-					<xs:documentation>Digital audio tape cassette</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AE">
-				<xs:annotation>
-					<xs:documentation>Audio disc</xs:documentation>
-					<xs:documentation>Audio disc (excluding CD-Audio)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AF">
-				<xs:annotation>
-					<xs:documentation>Audio tape</xs:documentation>
-					<xs:documentation>Audio tape (analogue open reel tape)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AG">
-				<xs:annotation>
-					<xs:documentation>MiniDisc</xs:documentation>
-					<xs:documentation>Sony MiniDisc format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AH">
-				<xs:annotation>
-					<xs:documentation>CD-Extra</xs:documentation>
-					<xs:documentation>Audio compact disc with part CD-ROM content, also termed CD-Plus or Enhanced-CD: use for ‘blue book’ and ‘yellow/red book’ two-session discs</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AI">
-				<xs:annotation>
-					<xs:documentation>DVD Audio</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AJ">
-				<xs:annotation>
-					<xs:documentation>Downloadable audio file</xs:documentation>
-					<xs:documentation>Audio recording downloadable online</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AK">
-				<xs:annotation>
-					<xs:documentation>Pre-recorded digital audio player</xs:documentation>
-					<xs:documentation>For example, Playaway audiobook and player: use coding in Product Form Detail to specify the recording format, if required</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AL">
-				<xs:annotation>
-					<xs:documentation>Pre-recorded SD card</xs:documentation>
-					<xs:documentation>For example, Audiofy audiobook chip</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AZ">
-				<xs:annotation>
-					<xs:documentation>Other audio format</xs:documentation>
-					<xs:documentation>Other audio format not specified by AB to AL</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BA">
-				<xs:annotation>
-					<xs:documentation>Book</xs:documentation>
-					<xs:documentation>Book – detail unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BB">
-				<xs:annotation>
-					<xs:documentation>Hardback</xs:documentation>
-					<xs:documentation>Hardback or cased book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BC">
-				<xs:annotation>
-					<xs:documentation>Paperback / softback</xs:documentation>
-					<xs:documentation>Paperback or other softback book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BD">
-				<xs:annotation>
-					<xs:documentation>Loose-leaf</xs:documentation>
-					<xs:documentation>Loose-leaf book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BE">
-				<xs:annotation>
-					<xs:documentation>Spiral bound</xs:documentation>
-					<xs:documentation>Spiral, comb or coil bound book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BF">
-				<xs:annotation>
-					<xs:documentation>Pamphlet</xs:documentation>
-					<xs:documentation>Pamphlet or brochure, stapled; German ‘geheftet’. Includes low-extent wire-stitched books bound without a distinct spine (eg many comic books)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BG">
-				<xs:annotation>
-					<xs:documentation>Leather / fine binding</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BH">
-				<xs:annotation>
-					<xs:documentation>Board book</xs:documentation>
-					<xs:documentation>Child’s book with all pages printed on board</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BI">
-				<xs:annotation>
-					<xs:documentation>Rag book</xs:documentation>
-					<xs:documentation>Child’s book with all pages printed on textile</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BJ">
-				<xs:annotation>
-					<xs:documentation>Bath book</xs:documentation>
-					<xs:documentation>Child’s book printed on waterproof material</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BK">
-				<xs:annotation>
-					<xs:documentation>Novelty book</xs:documentation>
-					<xs:documentation>A book whose novelty consists wholly or partly in a format which cannot be described by any other available code – a ‘conventional’ format code is always to be preferred; one or more Product Form Detail codes, eg from the B2nn group, should be used whenever possible to provide additional description</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BL">
-				<xs:annotation>
-					<xs:documentation>Slide bound</xs:documentation>
-					<xs:documentation>Slide bound book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BM">
-				<xs:annotation>
-					<xs:documentation>Big book</xs:documentation>
-					<xs:documentation>Extra-large format for teaching etc; this format and terminology may be specifically UK; required as a top-level differentiator</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BN">
-				<xs:annotation>
-					<xs:documentation>Part-work (fascículo)</xs:documentation>
-					<xs:documentation>A part-work issued with its own ISBN and intended to be collected and bound into a complete book</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BO">
-				<xs:annotation>
-					<xs:documentation>Fold-out book or chart</xs:documentation>
-					<xs:documentation>Concertina-folded book or chart, designed to fold to pocket or regular page size: use for German ‘Leporello’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BP">
-				<xs:annotation>
-					<xs:documentation>Foam book</xs:documentation>
-					<xs:documentation>A children’s book whose cover and pages are made of foam</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="BZ">
-				<xs:annotation>
-					<xs:documentation>Other book format</xs:documentation>
-					<xs:documentation>Other book format or binding not specified by BB to BP</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="CA">
-				<xs:annotation>
-					<xs:documentation>Sheet map</xs:documentation>
-					<xs:documentation>Sheet map – detail unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="CB">
-				<xs:annotation>
-					<xs:documentation>Sheet map, folded</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="CC">
-				<xs:annotation>
-					<xs:documentation>Sheet map, flat</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="CD">
-				<xs:annotation>
-					<xs:documentation>Sheet map, rolled</xs:documentation>
-					<xs:documentation>See Code List 80 for ‘rolled in tube’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="CE">
-				<xs:annotation>
-					<xs:documentation>Globe</xs:documentation>
-					<xs:documentation>Globe or planisphere</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="CZ">
-				<xs:annotation>
-					<xs:documentation>Other cartographic</xs:documentation>
-					<xs:documentation>Other cartographic format not specified by CB to CE</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DA">
-				<xs:annotation>
-					<xs:documentation>Digital</xs:documentation>
-					<xs:documentation>Digital or multimedia (detail unspecified)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DB">
-				<xs:annotation>
-					<xs:documentation>CD-ROM</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DC">
-				<xs:annotation>
-					<xs:documentation>CD-I</xs:documentation>
-					<xs:documentation>CD interactive, use for ‘green book’ discs</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DD">
-				<xs:annotation>
-					<xs:documentation>DVD</xs:documentation>
-					<xs:documentation>DEPRECATED – use VI for DVD video, AI for DVD audio, DI for DVD-ROM</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DE">
-				<xs:annotation>
-					<xs:documentation>Game cartridge</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DF">
-				<xs:annotation>
-					<xs:documentation>Diskette</xs:documentation>
-					<xs:documentation>AKA ‘floppy disc’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DG">
-				<xs:annotation>
-					<xs:documentation>Electronic book text</xs:documentation>
-					<xs:documentation>Electronic book text in proprietary or open standard format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DH">
-				<xs:annotation>
-					<xs:documentation>Online resource</xs:documentation>
-					<xs:documentation>An electronic database or other resource or service accessible through online networks</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DI">
-				<xs:annotation>
-					<xs:documentation>DVD-ROM</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DJ">
-				<xs:annotation>
-					<xs:documentation>Secure Digital (SD) Memory Card</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DK">
-				<xs:annotation>
-					<xs:documentation>Compact Flash Memory Card</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DL">
-				<xs:annotation>
-					<xs:documentation>Memory Stick Memory Card</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DM">
-				<xs:annotation>
-					<xs:documentation>USB Flash Drive</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DN">
-				<xs:annotation>
-					<xs:documentation>Double-sided CD/DVD</xs:documentation>
-					<xs:documentation>Double-sided disc, one side CD-Audio/CD-ROM, other side DVD-Audio/DVD-Video/DVD-ROM (at least one side must be -ROM)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DO">
-				<xs:annotation>
-					<xs:documentation>Digital product license key</xs:documentation>
-					<xs:documentation>Digital product license delivered through the retail supply chain as a physical ‘key’, typically a card or booklet containing a code enabling the purchaser to download or activate the associated product</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="DZ">
-				<xs:annotation>
-					<xs:documentation>Other digital</xs:documentation>
-					<xs:documentation>Other digital or multimedia not specified by DB to DN</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="FA">
-				<xs:annotation>
-					<xs:documentation>Film or transparency</xs:documentation>
-					<xs:documentation>Film or transparency – detail unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="FB">
-				<xs:annotation>
-					<xs:documentation>Film</xs:documentation>
-					<xs:documentation>Continuous film or filmstrip: DEPRECATED – use FE or FF</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="FC">
-				<xs:annotation>
-					<xs:documentation>Slides</xs:documentation>
-					<xs:documentation>Photographic transparencies mounted for projection</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="FD">
-				<xs:annotation>
-					<xs:documentation>OHP transparencies</xs:documentation>
-					<xs:documentation>Transparencies for overhead projector</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="FE">
-				<xs:annotation>
-					<xs:documentation>Filmstrip</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="FF">
-				<xs:annotation>
-					<xs:documentation>Film</xs:documentation>
-					<xs:documentation>Continuous movie film as opposed to filmstrip</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="FZ">
-				<xs:annotation>
-					<xs:documentation>Other film or transparency format</xs:documentation>
-					<xs:documentation>Other film or transparency format not specified by FB to FF</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="MA">
-				<xs:annotation>
-					<xs:documentation>Microform</xs:documentation>
-					<xs:documentation>Microform – detail unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="MB">
-				<xs:annotation>
-					<xs:documentation>Microfiche</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="MC">
-				<xs:annotation>
-					<xs:documentation>Microfilm</xs:documentation>
-					<xs:documentation>Roll microfilm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="MZ">
-				<xs:annotation>
-					<xs:documentation>Other microform</xs:documentation>
-					<xs:documentation>Other microform not specified by MB or MC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PA">
-				<xs:annotation>
-					<xs:documentation>Miscellaneous print</xs:documentation>
-					<xs:documentation>Miscellaneous printed material – detail unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PB">
-				<xs:annotation>
-					<xs:documentation>Address book</xs:documentation>
-					<xs:documentation>May use product form detail codes P201 to P204 to specify binding</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PC">
-				<xs:annotation>
-					<xs:documentation>Calendar</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PD">
-				<xs:annotation>
-					<xs:documentation>Cards</xs:documentation>
-					<xs:documentation>Cards, flash cards (eg for teaching reading)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PE">
-				<xs:annotation>
-					<xs:documentation>Copymasters</xs:documentation>
-					<xs:documentation>Copymasters, photocopiable sheets</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PF">
-				<xs:annotation>
-					<xs:documentation>Diary</xs:documentation>
-					<xs:documentation>May use product form detail codes P201 to P204 to specify binding</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PG">
-				<xs:annotation>
-					<xs:documentation>Frieze</xs:documentation>
-					<xs:documentation>Narrow strip-shaped printed sheet used mostly for education or children’s products (eg depicting alphabet, number line, procession of illustrated characters etc). Usually intended for horizontal display</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PH">
-				<xs:annotation>
-					<xs:documentation>Kit</xs:documentation>
-					<xs:documentation>Parts for post-purchase assembly</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PI">
-				<xs:annotation>
-					<xs:documentation>Sheet music</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PJ">
-				<xs:annotation>
-					<xs:documentation>Postcard book or pack</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PK">
-				<xs:annotation>
-					<xs:documentation>Poster</xs:documentation>
-					<xs:documentation>Poster for retail sale – see also XF</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PL">
-				<xs:annotation>
-					<xs:documentation>Record book</xs:documentation>
-					<xs:documentation>Record book (eg ‘birthday book’, ‘baby book’): may use product form detail codes P201 to P204 to specify binding</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PM">
-				<xs:annotation>
-					<xs:documentation>Wallet or folder</xs:documentation>
-					<xs:documentation>Wallet or folder (containing loose sheets etc): it is preferable to code the contents and treat ‘wallet’ as packaging (List 80), but if this is not possible the product as a whole may be coded as a ‘wallet’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PN">
-				<xs:annotation>
-					<xs:documentation>Pictures or photographs</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PO">
-				<xs:annotation>
-					<xs:documentation>Wallchart</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PP">
-				<xs:annotation>
-					<xs:documentation>Stickers</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PQ">
-				<xs:annotation>
-					<xs:documentation>Plate (lámina)</xs:documentation>
-					<xs:documentation>A book-sized (as opposed to poster-sized) sheet, usually in color or high quality print</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PR">
-				<xs:annotation>
-					<xs:documentation>Notebook / blank book</xs:documentation>
-					<xs:documentation>A book with all pages blank for the buyer’s own use: may use product form detail codes P201 to P204 to specify binding</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PS">
-				<xs:annotation>
-					<xs:documentation>Organizer</xs:documentation>
-					<xs:documentation>May use product form detail codes P201 to P204 to specify binding</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PT">
-				<xs:annotation>
-					<xs:documentation>Bookmark</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PZ">
-				<xs:annotation>
-					<xs:documentation>Other printed item</xs:documentation>
-					<xs:documentation>Other printed item not specified by PB to PT</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VA">
-				<xs:annotation>
-					<xs:documentation>Video</xs:documentation>
-					<xs:documentation>Video – detail unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VB">
-				<xs:annotation>
-					<xs:documentation>Video, VHS, PAL</xs:documentation>
-					<xs:documentation>DEPRECATED – use new VJ</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VC">
-				<xs:annotation>
-					<xs:documentation>Video, VHS, NTSC</xs:documentation>
-					<xs:documentation>DEPRECATED – use new VJ</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VD">
-				<xs:annotation>
-					<xs:documentation>Video, Betamax, PAL</xs:documentation>
-					<xs:documentation>DEPRECATED – use new VK</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VE">
-				<xs:annotation>
-					<xs:documentation>Video, Betamax, NTSC</xs:documentation>
-					<xs:documentation>DEPRECATED – use new VK</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VF">
-				<xs:annotation>
-					<xs:documentation>Videodisc</xs:documentation>
-					<xs:documentation>eg Laserdisc</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VG">
-				<xs:annotation>
-					<xs:documentation>Video, VHS, SECAM</xs:documentation>
-					<xs:documentation>DEPRECATED – use new VJ</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VH">
-				<xs:annotation>
-					<xs:documentation>Video, Betamax, SECAM</xs:documentation>
-					<xs:documentation>DEPRECATED – use new VK</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VI">
-				<xs:annotation>
-					<xs:documentation>DVD video</xs:documentation>
-					<xs:documentation>DVD video: specify TV standard in List 78</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VJ">
-				<xs:annotation>
-					<xs:documentation>VHS video</xs:documentation>
-					<xs:documentation>VHS videotape: specify TV standard in List 78</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VK">
-				<xs:annotation>
-					<xs:documentation>Betamax video</xs:documentation>
-					<xs:documentation>Betamax videotape: specify TV standard in List 78</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VL">
-				<xs:annotation>
-					<xs:documentation>VCD</xs:documentation>
-					<xs:documentation>VideoCD</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VM">
-				<xs:annotation>
-					<xs:documentation>SVCD</xs:documentation>
-					<xs:documentation>Super VideoCD</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VN">
-				<xs:annotation>
-					<xs:documentation>HD DVD</xs:documentation>
-					<xs:documentation>High definition DVD disc, Toshiba HD DVD format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VO">
-				<xs:annotation>
-					<xs:documentation>Blu-ray</xs:documentation>
-					<xs:documentation>High definition DVD disc, Sony Blu-ray format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VP">
-				<xs:annotation>
-					<xs:documentation>UMD Video</xs:documentation>
-					<xs:documentation>Sony Universal Media disc</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="VZ">
-				<xs:annotation>
-					<xs:documentation>Other video format</xs:documentation>
-					<xs:documentation>Other video format not specified by VB to VP</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="WW">
-				<xs:annotation>
-					<xs:documentation>Mixed media product</xs:documentation>
-					<xs:documentation>A product consisting of two or more items in different media or different product forms, eg book and CD-ROM, book and toy, hardback book and e-book, etc</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="WX">
-				<xs:annotation>
-					<xs:documentation>Multiple copy pack</xs:documentation>
-					<xs:documentation>A product containing multiple copies of one or more items packaged together for retail sale, consisting of either (a) several copies of a single item (eg 6 copies of a graded reader), or (b) several copies of each of several items (eg 3 copies each of 3 different graded readers), or (c) several copies of one or more single items plus a single copy of one or more related items (eg 30 copies of a pupil’s textbook plus 1 of teacher’s text). NOT TO BE CONFUSED WITH: multi-volume sets, or sets containing a single copy of a number of different items (boxed, slip-cased or otherwise); items with several components of different physical forms (see WW); or packs intended for trade distribution only, where the contents are retailed separately (see XC, XE, XL)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XA">
-				<xs:annotation>
-					<xs:documentation>Trade-only material</xs:documentation>
-					<xs:documentation>Trade-only material (unspecified)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XB">
-				<xs:annotation>
-					<xs:documentation>Dumpbin – empty</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XC">
-				<xs:annotation>
-					<xs:documentation>Dumpbin – filled</xs:documentation>
-					<xs:documentation>Dumpbin with contents</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XD">
-				<xs:annotation>
-					<xs:documentation>Counterpack – empty</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XE">
-				<xs:annotation>
-					<xs:documentation>Counterpack – filled</xs:documentation>
-					<xs:documentation>Counterpack with contents</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XF">
-				<xs:annotation>
-					<xs:documentation>Poster, promotional</xs:documentation>
-					<xs:documentation>Promotional poster for display, not for sale – see also PK</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XG">
-				<xs:annotation>
-					<xs:documentation>Shelf strip</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XH">
-				<xs:annotation>
-					<xs:documentation>Window piece</xs:documentation>
-					<xs:documentation>Promotional piece for shop window display</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XI">
-				<xs:annotation>
-					<xs:documentation>Streamer</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XJ">
-				<xs:annotation>
-					<xs:documentation>Spinner</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XK">
-				<xs:annotation>
-					<xs:documentation>Large book display</xs:documentation>
-					<xs:documentation>Large scale facsimile of book for promotional display</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XL">
-				<xs:annotation>
-					<xs:documentation>Shrink-wrapped pack</xs:documentation>
-					<xs:documentation>A quantity pack with its own product code, for trade supply only: the retail items it contains are intended for sale individually – see also WX. For products or product bundles supplied shrink-wrapped for retail sale, use the Product Form code of the contents plus code 21 from List 80</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XM">
-				<xs:annotation>
-					<xs:documentation>Boxed pack</xs:documentation>
-					<xs:documentation>A quantity pack with its own product code, for trade supply only: the retail items it contains are intended for sale individually – see also WX. For products or product bundles supplied boxed for retail sale, use the Product Form code of the contents plus code 09 from List 80</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="XZ">
-				<xs:annotation>
-					<xs:documentation>Other point of sale</xs:documentation>
-					<xs:documentation>Other point of sale material not specified by XB to XL</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZA">
-				<xs:annotation>
-					<xs:documentation>General merchandise</xs:documentation>
-					<xs:documentation>General merchandise – unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZB">
-				<xs:annotation>
-					<xs:documentation>Doll</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZC">
-				<xs:annotation>
-					<xs:documentation>Soft toy</xs:documentation>
-					<xs:documentation>Soft or plush toy</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZD">
-				<xs:annotation>
-					<xs:documentation>Toy</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZE">
-				<xs:annotation>
-					<xs:documentation>Game</xs:documentation>
-					<xs:documentation>Board game, or other game (except computer game: see DE)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZF">
-				<xs:annotation>
-					<xs:documentation>T-shirt</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZG">
-				<xs:annotation>
-					<xs:documentation>E-book reader</xs:documentation>
-					<xs:documentation>Dedicated e-book reading device, typically with mono screen</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZH">
-				<xs:annotation>
-					<xs:documentation>Tablet computer</xs:documentation>
-					<xs:documentation>General purpose tablet computer, typically with color screen</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZI">
-				<xs:annotation>
-					<xs:documentation>Audiobook player</xs:documentation>
-					<xs:documentation>Dedicated audiobook player device, typically including book-related features like bookmarking</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZJ">
-				<xs:annotation>
-					<xs:documentation>Jigsaw</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZY">
-				<xs:annotation>
-					<xs:documentation>Other apparel</xs:documentation>
-					<xs:documentation>Other apparel items not specified by ZB to ZJ, including promotional or branded scarves, caps, aprons etc</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ZZ">
-				<xs:annotation>
-					<xs:documentation>Other merchandise</xs:documentation>
-					<xs:documentation>Other merchandise not specified by ZB to ZY</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List8">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 8">Book form detail</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>A-format paperback</xs:documentation>
-					<xs:documentation>DEPRECATED</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>B-format paperback</xs:documentation>
-					<xs:documentation>‘B’ format paperback: UK 198 x 129 mm – DEPRECATED</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>C-format paperback</xs:documentation>
-					<xs:documentation>‘C’ format paperback: UK 216 x 135 mm – DEPRECATED</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>Paper over boards</xs:documentation>
-					<xs:documentation>DEPRECATED</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>Cloth</xs:documentation>
-					<xs:documentation>DEPRECATED</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>With dust jacket</xs:documentation>
-					<xs:documentation>DEPRECATED</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="07">
-				<xs:annotation>
-					<xs:documentation>Reinforced binding</xs:documentation>
-					<xs:documentation>DEPRECATED</xs:documentation>
+					<xs:documentation>ARK</xs:documentation>
+					<xs:documentation>Archival Resource Key, as a URL (including the address of the ARK resolver provided by eg a national library)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List9">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 9">Product classification type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 9">Product classification type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>WCO Harmonized System</xs:documentation>
-					<xs:documentation>World Customs Organization Harmonized Commodity Coding and Description System. Use 6 or 8 digits, without punctuation</xs:documentation>
+					<xs:documentation>World Customs Organization Harmonized Commodity Coding and Description System. Use 6 (or occasionally 8 or 10) digits, without punctuation</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>UNSPSC</xs:documentation>
-					<xs:documentation>UN Standard Product and Service Classification</xs:documentation>
+					<xs:documentation>UN Standard Product and Service Classification. Use 8 (or occasionally 10) digits, without punctuation</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
@@ -1835,7 +565,7 @@
 			<xs:enumeration value="05">
 				<xs:annotation>
 					<xs:documentation>TARIC</xs:documentation>
-					<xs:documentation>EU TARIC codes, an extended version of the Harmonized System</xs:documentation>
+					<xs:documentation>EU TARIC codes, an extended version of the Harmonized System. Use 10 digits, without punctuation</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
@@ -1859,13 +589,13 @@
 			<xs:enumeration value="09">
 				<xs:annotation>
 					<xs:documentation>CPA</xs:documentation>
-					<xs:documentation>Statistical Classification of Products by Activity in the European Economic Community, see http://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=LST_NOM_DTL&amp;StrNom=CPA_2008. Up to six digits, with one or two periods. For example, printed children’s books are ‘58.11.13’, but the periods are normally ommited in ONIX</xs:documentation>
+					<xs:documentation>Statistical Classification of Products by Activity in the European Economic Community, see http://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=LST_NOM_DTL&amp;StrNom=CPA_2008. Use 6 digits, without punctuation. For example, printed children’s books are ‘58.11.13’, but the periods are normally ommited in ONIX</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="10">
 				<xs:annotation>
 					<xs:documentation>NCM</xs:documentation>
-					<xs:documentation>Mercosur/Mercosul Common Nomenclature, based on the Harmonised System</xs:documentation>
+					<xs:documentation>Mercosur/Mercosul Common Nomenclature, based on the Harmonised System. Use 8 digits, without punctuation</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="11">
@@ -1882,395 +612,9 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="List10">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 10">Epublication type code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="000">
-				<xs:annotation>
-					<xs:documentation>Epublication ‘content package’</xs:documentation>
-					<xs:documentation>An epublication viewed as a unique package of content which may be converted into any of a number of different types for delivery to the consumer. This code is used when an ONIX &lt;Product&gt; record describes the content package and lists within the record the different forms in which it is available</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="001">
-				<xs:annotation>
-					<xs:documentation>HTML</xs:documentation>
-					<xs:documentation>An epublication delivered in a basic, unprotected, HTML format. Do NOT use for HTML-based formats which include DRM protection</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="002">
-				<xs:annotation>
-					<xs:documentation>PDF</xs:documentation>
-					<xs:documentation>An epublication delivered in a basic, unprotected, PDF format. Do NOT use for PDF-based formats which include DRM protection</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="003">
-				<xs:annotation>
-					<xs:documentation>PDF-Merchant</xs:documentation>
-					<xs:documentation>An epublication delivered in PDF format, capable of being read in the standard Acrobat Reader, and protected by PDF-Merchant DRM features. (This format is no longer supported for new applications)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="004">
-				<xs:annotation>
-					<xs:documentation>Adobe Ebook Reader</xs:documentation>
-					<xs:documentation>An epublication delivered in an enhanced PDF format, using Adobe’s proprietary EBX DRM, capable of being read in the Adobe Ebook Reader software, on any platform which can support this software, which was formerly known as Glassbook</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="005">
-				<xs:annotation>
-					<xs:documentation>Microsoft Reader Level 1/Level 3</xs:documentation>
-					<xs:documentation>An epublication delivered in an unencrypted Microsoft .LIT format, capable of being read in the Microsoft Reader software at any level, on any platform which can support this software. (Level 3 differs from Level 1 only in that it embeds the name of the original purchaser)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="006">
-				<xs:annotation>
-					<xs:documentation>Microsoft Reader Level 5</xs:documentation>
-					<xs:documentation>An epublication delivered in the Microsoft .LIT format, with full encryption, capable of being read in the Microsoft Reader software at Level 5, on any platform which can support this software</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="007">
-				<xs:annotation>
-					<xs:documentation>NetLibrary</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary HTML- or OEBF-based format, capable of being read only through subscription to the NetLibrary service</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="008">
-				<xs:annotation>
-					<xs:documentation>MetaText</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary format through a web browser, capable of being read only through subscription to the MetaText service (the educational division of NetLibrary)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="009">
-				<xs:annotation>
-					<xs:documentation>MightyWords</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary PDF-based format, capable of being read only through subscription to the MightyWords service</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="010">
-				<xs:annotation>
-					<xs:documentation>eReader (AKA Palm Reader)</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary HTML-based format, capable of being read in reading software which may be used on handheld devices using the Palm OS or Pocket PC/Windows CE operating systems</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="011">
-				<xs:annotation>
-					<xs:documentation>Softbook</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary format capable of being read in reading software which is specific to the Softbook hardware platform. Also capable of being read on the Softbook’s successor, the Gemstar REB 1200</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="012">
-				<xs:annotation>
-					<xs:documentation>RocketBook</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary .RB format, capable of being read in reading software which is specific to the RocketBook hardware platform. Also capable of being read on the RocketBook’s successor, the Gemstar REB 1100</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="013">
-				<xs:annotation>
-					<xs:documentation>Gemstar REB 1100</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary .RB format, capable of being read in reading software which is specific to the Gemstar REB 1100 hardware platform. Also capable of being read on the RocketBook with some loss of functionality</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="014">
-				<xs:annotation>
-					<xs:documentation>Gemstar REB 1200</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary format, capable of being read in reading software which is specific to the Gemstar REB 1200 hardware platform. Also capable of being read on the Softbook with some loss of functionality</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="015">
-				<xs:annotation>
-					<xs:documentation>Franklin eBookman</xs:documentation>
-					<xs:documentation>An epublication delivered in Franklin’s proprietary HTML-based format, capable of being read in reading software which is specific to the Franklin eBookman platform</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="016">
-				<xs:annotation>
-					<xs:documentation>Books24x7</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary XML-based format and available for online access only through subscription to the Books24x7 service</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="017">
-				<xs:annotation>
-					<xs:documentation>DigitalOwl</xs:documentation>
-					<xs:documentation>An epublication available through DigitalOwl proprietary packaging, distribution and DRM software, delivered in a variety of formats across a range of platforms</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="018">
-				<xs:annotation>
-					<xs:documentation>Handheldmed</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary HTML-based format, capable of being read in Handheldmed reader software on Palm OS, Windows, and EPOC/Psion handheld devices, available only through the Handheldmed service</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="019">
-				<xs:annotation>
-					<xs:documentation>WizeUp</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary ???-based format and available for download only through the WizeUp service</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="020">
-				<xs:annotation>
-					<xs:documentation>TK3</xs:documentation>
-					<xs:documentation>An epublication delivered in the proprietary TK3 format, capable of being read only in the TK3 reader software supplied by Night Kitchen Inc, on any platform which can support this software</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="021">
-				<xs:annotation>
-					<xs:documentation>Litraweb</xs:documentation>
-					<xs:documentation>An epublication delivered in an encrypted .RTF format, capable of being read only in the Litraweb Visor software, and available only from Litraweb.com</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="022">
-				<xs:annotation>
-					<xs:documentation>MobiPocket</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary format, capable of being read in the MobiPocket software on PalmOS, WindowsCE /Pocket PC, Franklin eBookman, and EPOC32 handheld devices, available through the MobiPocket service. Includes Amazon Kindle formats up to and including version 7 – but prefer code 031 for version 7, and always use 031 for KF8</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="023">
-				<xs:annotation>
-					<xs:documentation>Open Ebook</xs:documentation>
-					<xs:documentation>An epublication delivered in the standard distribution format specified in the Open Ebook Publication Structure (OEBPS) format and capable of being read in any OEBPS-compliant reading system. Includes EPUB format up to and including version 2 – but prefer code 029 for EPUB 2, and always use 029 for EPUB 3</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="024">
-				<xs:annotation>
-					<xs:documentation>Town Compass DataViewer</xs:documentation>
-					<xs:documentation>An epublication delivered in a proprietary format, capable of being read in Town Compass DataViewer reader software on a Palm OS handheld device</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="025">
-				<xs:annotation>
-					<xs:documentation>TXT</xs:documentation>
-					<xs:documentation>An epublication delivered in an openly available .TXT format, with ASCII or UTF-8 encoding, as used for example in Project Gutenberg</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="026">
-				<xs:annotation>
-					<xs:documentation>ExeBook</xs:documentation>
-					<xs:documentation>An epublication delivered as a self-executing file including its own reader software, and created with proprietary ExeBook Self-Publisher software</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="027">
-				<xs:annotation>
-					<xs:documentation>Sony BBeB</xs:documentation>
-					<xs:documentation>An epublication in a Sony proprietary format for use with the Sony Reader and LIBRIé reading devices</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="028">
-				<xs:annotation>
-					<xs:documentation>VitalSource Bookshelf</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="029">
-				<xs:annotation>
-					<xs:documentation>EPUB</xs:documentation>
-					<xs:documentation>An epublication delivered using the Open Publication Structure / OPS Container Format standard of the International Digital Publishing Forum (IDPF). [This value was originally defined as ‘Adobe Digital Editions’, which is not an epublication format but a reader which supports PDF or EPUB (IDPF) formats. Since PDF is already covered by code 002, it was agreed, and announced to the ONIX listserv in September 2009, that code 029 should be refined to represent EPUB format]</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="030">
-				<xs:annotation>
-					<xs:documentation>MyiLibrary</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="031">
-				<xs:annotation>
-					<xs:documentation>Kindle</xs:documentation>
-					<xs:documentation>Amazon proprietary file format derived from Mobipocket format, used for Kindle devices and Kindle reader software</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="032">
-				<xs:annotation>
-					<xs:documentation>Google Edition</xs:documentation>
-					<xs:documentation>An epublication made available by Google in association with a publisher; readable online on a browser-enabled device and offline on designated ebook readers</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="033">
-				<xs:annotation>
-					<xs:documentation>Vook</xs:documentation>
-					<xs:documentation>An epublication in a proprietary format combining text and video content and available to be used online or as a downloadable application for a mobile device – see www.vook.com</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="034">
-				<xs:annotation>
-					<xs:documentation>DXReader</xs:documentation>
-					<xs:documentation>An epublication in a proprietary format for use with DXReader software</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="035">
-				<xs:annotation>
-					<xs:documentation>EBL</xs:documentation>
-					<xs:documentation>An epublication in a format proprietary to the Ebook Library service</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="036">
-				<xs:annotation>
-					<xs:documentation>Ebrary</xs:documentation>
-					<xs:documentation>An epublication in a format proprietary to the Ebrary service</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="037">
-				<xs:annotation>
-					<xs:documentation>iSilo</xs:documentation>
-					<xs:documentation>An epublication in a proprietary format for use with iSilo software on various hardware platforms</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="038">
-				<xs:annotation>
-					<xs:documentation>Plucker</xs:documentation>
-					<xs:documentation>An epublication in a proprietary format for use with Plucker reader software on Palm and other handheld devices</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="039">
-				<xs:annotation>
-					<xs:documentation>VitalBook</xs:documentation>
-					<xs:documentation>A format proprietary to the VitalSource service</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="040">
-				<xs:annotation>
-					<xs:documentation>Book ‘app’ for iOS</xs:documentation>
-					<xs:documentation>Epublication packaged as an application for iOS (eg Apple iPhone, iPad etc) containing both executable code and content. Content can be described with &lt;ProductContentType&gt;</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="041">
-				<xs:annotation>
-					<xs:documentation>Android ‘app’</xs:documentation>
-					<xs:documentation>Epublication packaged as an application for Android (eg Android phone or tablet) containing both executable code and content. Content can be described with &lt;ProductContentType&gt;</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="042">
-				<xs:annotation>
-					<xs:documentation>Other ‘app’</xs:documentation>
-					<xs:documentation>Epublication packaged as an application. Technical requirements such as target operating system and/or device should be provided in &lt;EpubTypeNote&gt;. Content can be described with &lt;ProductContentType&gt;</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="043">
-				<xs:annotation>
-					<xs:documentation>XPS</xs:documentation>
-					<xs:documentation>XML Paper Specification format [File extension .xps] for (eg) Blio</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="044">
-				<xs:annotation>
-					<xs:documentation>iBook</xs:documentation>
-					<xs:documentation>Apple’s iBook format (a proprietary extension of EPUB), can only be read on Apple iOS devices</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="045">
-				<xs:annotation>
-					<xs:documentation>ePIB</xs:documentation>
-					<xs:documentation>Proprietary format based on EPUB used by Barnes and Noble for fixed-format e-books, readable on NOOK devices and Nook reader software</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="046">
-				<xs:annotation>
-					<xs:documentation>SCORM</xs:documentation>
-					<xs:documentation>Sharable Content Object Reference Model, standard content and packaging format for e-learning objects</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="047">
-				<xs:annotation>
-					<xs:documentation>EBP</xs:documentation>
-					<xs:documentation>E-book Plus (proprietary Norwegian e-book format based on HTML5 documents packaged within a zipped .ebp file)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="048">
-				<xs:annotation>
-					<xs:documentation>Page Perfect</xs:documentation>
-					<xs:documentation>Proprietary format based on PDF used by Barnes and Noble for fixed-format e-books, readable on some NOOK devices and Nook reader software</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="098">
-				<xs:annotation>
-					<xs:documentation>Multiple formats</xs:documentation>
-					<xs:documentation>Product consists of parts in different formats</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="099">
-				<xs:annotation>
-					<xs:documentation>Unspecified</xs:documentation>
-					<xs:documentation>Unknown, or no code yet assigned for this format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List11">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 11">Epublication format code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>HTML</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>PDF</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>Microsoft Reader</xs:documentation>
-					<xs:documentation>‘.LIT’ file format used by Microsoft Reader software</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>RocketBook</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>Rich text format (RTF)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>Open Ebook Publication Structure (OEBPS) format standard</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="07">
-				<xs:annotation>
-					<xs:documentation>XML</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="08">
-				<xs:annotation>
-					<xs:documentation>SGML</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="09">
-				<xs:annotation>
-					<xs:documentation>EXE</xs:documentation>
-					<xs:documentation>‘.EXE’ file format used when an epublication is delivered as a self-executing package of software and content</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="10">
-				<xs:annotation>
-					<xs:documentation>ASCII</xs:documentation>
-					<xs:documentation>‘.TXT’ file format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="11">
-				<xs:annotation>
-					<xs:documentation>MobiPocket format</xs:documentation>
-					<xs:documentation>Proprietary file format used for the MobiPocket reader software</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="List12">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 12">Trade category code</xs:documentation>
+			<xs:documentation source="ONIX Code List 12">Trade category</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -2293,8 +637,8 @@
 			</xs:enumeration>
 			<xs:enumeration value="04">
 				<xs:annotation>
-					<xs:documentation>Pocket paperback</xs:documentation>
-					<xs:documentation>In countries where recognised as a distinct trade category, eg France ‘livre de poche’, Germany ‘Taschenbuch’, Italy ‘tascabile’, Spain ‘libro de bolsillo’</xs:documentation>
+					<xs:documentation>Pocket book</xs:documentation>
+					<xs:documentation>In countries where recognised as a distinct trade category, eg France « livre de poche », Germany ,Taschenbuch‘, Italy «tascabile», Spain «libro de bolsillo»</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
@@ -2357,11 +701,35 @@
 					<xs:documentation>‘Short’ e-book (sometimes also called a ‘single’), typically containing a single short story, an essay or piece of long-form journalism</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Superpocket book</xs:documentation>
+					<xs:documentation>In countries where recognised as a distinct trade category, eg Italy «supertascabile». For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Beau-livre</xs:documentation>
+					<xs:documentation>Category of books, usually hardcover and of a large format (A4 or larger) and printed on high-quality paper, where the primary features are illustrations, and these are more important than text. Sometimes called ‘coffee-table books’ or ‘art books’ in English. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Podcast</xs:documentation>
+					<xs:documentation>Category of audio products typically distinguished by being free of charge (but which may be monetised through advertising content) and episodic. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Periodical</xs:documentation>
+					<xs:documentation>Category of books or e-books which are single issues of a periodical publication, sold as independent products. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List13">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 13">Series identifier type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 13">Series identifier type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -2414,8 +782,20 @@
 			</xs:enumeration>
 			<xs:enumeration value="29">
 				<xs:annotation>
-					<xs:documentation>Identifiant BNF des publications en série</xs:documentation>
-					<xs:documentation>French National Bibliography series ID, maintained by the Bibliothèque Nationale de France</xs:documentation>
+					<xs:documentation>BNF Control number</xs:documentation>
+					<xs:documentation>French National Bibliography series ID. Identifiant des publications en série maintenu par la Bibliothèque Nationale de France</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>ARK</xs:documentation>
+					<xs:documentation>Archival Resource Key, as a URL (including the address of the ARK resolver provided by eg a national library)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>ISSN-L</xs:documentation>
+					<xs:documentation>International Standard Serial Number ‘linking ISSN’, used when distinct from the serial ISSN. Unhyphenated, 8 digits. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -2446,14 +826,14 @@
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>All capitals</xs:documentation>
-					<xs:documentation>For example, ‘THE CONQUEST OF MEXICO’</xs:documentation>
+					<xs:documentation>For example, ‘THE CONQUEST OF MEXICO’. Use only when Sentence or Title case are not possible (for example because of system limitations). Do NOT use simply because title is (correctly) in all caps (eg ‘BBQ USA’)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List15">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 15">Title type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 15">Title type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -2544,7 +924,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List16">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 16">Work identifier type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 16">Work identifier type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -2574,7 +954,7 @@
 			<xs:enumeration value="15">
 				<xs:annotation>
 					<xs:documentation>ISBN-13</xs:documentation>
-					<xs:documentation>13-character ISBN of manifestation of work, when this is the only work identifier available</xs:documentation>
+					<xs:documentation>13-character ISBN of manifestation of work, when this is the only work identifier available (13 digits, without spaces or hyphens)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="18">
@@ -2611,7 +991,7 @@
 			<xs:enumeration value="A02">
 				<xs:annotation>
 					<xs:documentation>With</xs:documentation>
-					<xs:documentation>With or as told to: ‘ghost’ author of a literary work</xs:documentation>
+					<xs:documentation>With or as told to: ‘ghost’ or secondary author of a literary work (for clarity, should not be used for true ‘ghost’ authors who are not credited on the book and whose existence is secret)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="A03">
@@ -2833,13 +1213,13 @@
 			<xs:enumeration value="A40">
 				<xs:annotation>
 					<xs:documentation>Inked or colored by</xs:documentation>
-					<xs:documentation>Use for secondary creators when separate persons are named as having respectively drawn and inked/colored/finished artwork, eg for a graphic novel or comic book. Use with A12 for ‘drawn by’. Use A40 for 'finished by', but prefer more specific codes A46 to A48 instead of A40 unless the more specific secondary roles are inappropriate, unclear or unavailable</xs:documentation>
+					<xs:documentation>Use for secondary creators when separate persons are named as having respectively drawn and inked/colored/finished artwork, eg for a graphic novel or comic book. Use with A12 for ‘drawn by’. Use A40 for ‘finished by’, but prefer more specific codes A46 to A48 instead of A40 unless the more specific secondary roles are inappropriate, unclear or unavailable</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="A41">
 				<xs:annotation>
-					<xs:documentation>Pop-ups by</xs:documentation>
-					<xs:documentation>Designer of pop-ups in a pop-up book, who may be different from the illustrator</xs:documentation>
+					<xs:documentation>Paper engineering by</xs:documentation>
+					<xs:documentation>Designer or paper engineer of die-cuts, press-outs or of pop-ups in a pop-up book, who may be different from the illustrator</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="A42">
@@ -2882,6 +1262,12 @@
 				<xs:annotation>
 					<xs:documentation>Letterer</xs:documentation>
 					<xs:documentation>Creates comic book text balloons and other text elements (where this is a distinct role from script writer and/or illustrator)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A51">
+				<xs:annotation>
+					<xs:documentation>Research by</xs:documentation>
+					<xs:documentation>Person or organization responsible for performing research on which the work is based. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="A99">
@@ -3064,6 +1450,18 @@
 					<xs:documentation>Responsible overall for the scientific content of the publication</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="B30">
+				<xs:annotation>
+					<xs:documentation>Historical advisor</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B31">
+				<xs:annotation>
+					<xs:documentation>Original editor</xs:documentation>
+					<xs:documentation>Editor of the first edition (usually of a standard work) who is not an editor of the current edition. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="B99">
 				<xs:annotation>
 					<xs:documentation>Other adaptation by</xs:documentation>
@@ -3118,6 +1516,12 @@
 					<xs:documentation>Conductor of a musical performance</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="D04">
+				<xs:annotation>
+					<xs:documentation>Choreographer</xs:documentation>
+					<xs:documentation>Of a dance performance. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="D99">
 				<xs:annotation>
 					<xs:documentation>Other direction by</xs:documentation>
@@ -3127,7 +1531,7 @@
 			<xs:enumeration value="E01">
 				<xs:annotation>
 					<xs:documentation>Actor</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Performer in a dramatized production (including a voice actor in an audio production)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="E02">
@@ -3139,7 +1543,7 @@
 			<xs:enumeration value="E03">
 				<xs:annotation>
 					<xs:documentation>Narrator</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Where the narrator is a character in a dramatized production (including a voice actor in an audio production). For the ‘narrator’ of a non-dramatized audiobook, see code E07</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="E04">
@@ -3395,7 +1799,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List21">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 21">Edition type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 21">Edition type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="ABR">
@@ -3431,7 +1835,13 @@
 			<xs:enumeration value="BLL">
 				<xs:annotation>
 					<xs:documentation>Bilingual edition</xs:documentation>
-					<xs:documentation>Both languages should be specified in the ‘Language’ group. Use MLL for an edition in more than two languages</xs:documentation>
+					<xs:documentation>Both languages should be specified in the &lt;Language&gt; group. Use MLL for an edition in more than two languages</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BLP">
+				<xs:annotation>
+					<xs:documentation>Bilingual ‘facing page’ edition</xs:documentation>
+					<xs:documentation>Use only where the two languages are presented in parallel on facing pages, or in parallel columns of text on a single page (otherwise use BLL). Both languages should be specified in the &lt;Language&gt; group</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="BRL">
@@ -3500,10 +1910,16 @@
 					<xs:documentation>Content includes extensive illustrations which are not part of other editions</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="INT">
+				<xs:annotation>
+					<xs:documentation>International edition</xs:documentation>
+					<xs:documentation>A product aimed specifically at markets other than the country of original publication, usually titled as an ‘International edition’ and with specification and/or content changes</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="LTE">
 				<xs:annotation>
 					<xs:documentation>Large type / large print edition</xs:documentation>
-					<xs:documentation>Large print edition, print sizes 14 to 19 pt – see also ULP</xs:documentation>
+					<xs:documentation>Large print edition, print sizes 14 to 19pt – see also ULP</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="MCP">
@@ -3581,7 +1997,7 @@
 			<xs:enumeration value="TCH">
 				<xs:annotation>
 					<xs:documentation>Teacher’s edition</xs:documentation>
-					<xs:documentation>Where a text is available in both student and teacher’s editions; use also for instructor’s or leader’s editions</xs:documentation>
+					<xs:documentation>Where a text is available in both student and teacher’s editions; use also for instructor’s or leader’s editions, and for editions intended exclusively for educators where no specific student edition is available</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="UBR">
@@ -3618,7 +2034,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List22">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 22">Language role code</xs:documentation>
+			<xs:documentation source="ONIX Code List 22">Language role</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -3639,34 +2055,22 @@
 					<xs:documentation>Where different from language of text: used mainly for serials</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>Rights language</xs:documentation>
-					<xs:documentation>Language to which specified rights apply</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>Rights-excluded language</xs:documentation>
-					<xs:documentation>Language to which specified rights do not apply</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
 			<xs:enumeration value="06">
 				<xs:annotation>
 					<xs:documentation>Original language in a multilingual edition</xs:documentation>
-					<xs:documentation>Where the text in the original language is part of a bilingual or multilingual edition</xs:documentation>
+					<xs:documentation>Where the text in the original language is part of a bilingual or multilingual product</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="07">
 				<xs:annotation>
 					<xs:documentation>Translated language in a multilingual edition</xs:documentation>
-					<xs:documentation>Where the text in a translated language is part of a bilingual or multilingual edition</xs:documentation>
+					<xs:documentation>Where the text in a translated language is part of a bilingual or multilingual product</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Language of audio track</xs:documentation>
-					<xs:documentation>For example, on a DVD</xs:documentation>
+					<xs:documentation>For example, on an audiobook or video product. Use for the only available audio track, or where there are multiple tracks (eg on a DVD), for an alternate language audio track that is NOT the original. (In the latter case, use code 11 for the original language audio if it is included in the product, or code 10 to identify an original language that is not present in the product)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
@@ -3675,11 +2079,29 @@
 					<xs:documentation>For example, on a DVD</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Language of original audio track</xs:documentation>
+					<xs:documentation>Where the audio in the original language is NOT part of the current product</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Original language audio track in a multilingual product</xs:documentation>
+					<xs:documentation>Where the audio in the original language is part of a multilingual product with multiple audio tracks</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Language of notes</xs:documentation>
+					<xs:documentation>Use for the language of footnotes, endnotes, annotations or commentary, etc, where it is different from the language of the main text</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List23">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 23">Extent type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 23">Extent type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -3715,7 +2137,7 @@
 			<xs:enumeration value="06">
 				<xs:annotation>
 					<xs:documentation>Production page count</xs:documentation>
-					<xs:documentation>The total number of pages in a book, including unnumbered pages, front matter, back matter, etc. This includes any blank pages at the back that carry no content and are present only for convenience of printing and binding</xs:documentation>
+					<xs:documentation>The total number of pages in a book, including unnumbered pages, front matter, back matter, etc. This includes any extracts or ‘teaser’ material from other works, and blank pages at the back that carry no content and are present only for convenience of printing and binding</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="07">
@@ -3727,19 +2149,19 @@
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Number of pages in print counterpart</xs:documentation>
-					<xs:documentation>The total number of pages (equivalent to the Content page count) in the print counterpart of a digital product delivered without fixed pagination</xs:documentation>
+					<xs:documentation>The total number of pages (equivalent to the Content page count, code 11) in the print counterpart of a digital product delivered without fixed pagination, or of an audio product</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
 				<xs:annotation>
 					<xs:documentation>Duration</xs:documentation>
-					<xs:documentation>Total duration in time, expressed in the specified extent unit. This is the ‘running time’ equivalent of codes 05 or 11</xs:documentation>
+					<xs:documentation>Total duration in time, expressed in the specified extent unit. This is the ‘running time’ equivalent of code 11</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="10">
 				<xs:annotation>
 					<xs:documentation>Notional number of pages in digital product</xs:documentation>
-					<xs:documentation>An estimate of the number of ‘pages’ in a digital product delivered without fixed pagination, and with no print counterpart, given as an indication of the size of the work. Equivalent to code 08, but for exclusively digital products</xs:documentation>
+					<xs:documentation>An estimate of the number of ‘pages’ in a digital product delivered without fixed pagination, and with no print counterpart, given as an indication of the size of the work. Equivalent to code 08, but exclusively for digital or audio products</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="11">
@@ -3757,13 +2179,25 @@
 			<xs:enumeration value="13">
 				<xs:annotation>
 					<xs:documentation>Duration of introductory matter</xs:documentation>
-					<xs:documentation>Duration in time, expressed in the specified extent units, of introductory matter. This is the ‘running time’ equivalent of code 03, and comprises any significant amount of running time represented by announcements, titles, introduction or other material prefacing the main content</xs:documentation>
+					<xs:documentation>Duration in time, expressed in the specified extent units, of introductory matter. This is the ‘running time’ equivalent of code 03, and comprises any significant amount of running time represented by a musical intro, announcements, titles, introduction or other material prefacing the main content</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="14">
 				<xs:annotation>
 					<xs:documentation>Duration of main content</xs:documentation>
 					<xs:documentation>Duration in time, expressed in the specified extent units, of the main content. This is the ‘running time’ equivalent of code 00, and excludes time represented by announcements, titles, introduction or other prefatory material or ‘back matter’</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Duration of back matter</xs:documentation>
+					<xs:documentation>Duration in time, expressed in the specified extent units, of any content that follows the main content of a book. This may consist of an afterword, appendices, endnotes, end music etc. It excludes extracts or ‘teaser’ material from other works. This is the ‘running time’ equivalent of code 04</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Production duration</xs:documentation>
+					<xs:documentation>Duration in time, expressed in the specified extent units, of the complete content of a book. This is the ‘running time’ equivalent of code 06, and includes time represented by musical themes, announcements, titles, introductory and other prefatory material, plus ‘back matter’ such as any afterword, appendices, plus any extracts or ‘teaser’ material from other works</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="22">
@@ -3776,7 +2210,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List24">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 24">Extent unit code</xs:documentation>
+			<xs:documentation source="ONIX Code List 24">Extent unit</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="02">
@@ -3813,6 +2247,12 @@
 				<xs:annotation>
 					<xs:documentation>Tracks</xs:documentation>
 					<xs:documentation>Of an audiobook on CD (or a similarly divided selection of audio files). Conventionally, each track is 3–6 minutes of running time, and track counts are misleading and inappropriate if the average track duration is significantly more or less than this. Note that track breaks are not necessarily aligned with structural breaks in the text (eg chapter breaks)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Discs</xs:documentation>
+					<xs:documentation>Of an audiobook on multiple Red Book audio CDs. Conventionally, each disc is 60–70 minutes of running time, and disc counts are misleading and inappropriate if the average disc duration is significantly more or less than this (for example if the discs are Yellow Book CDs containing mp3 files). Note that disc breaks are not necessarily aligned with structural breaks in the text (eg chapter breaks). For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="14">
@@ -3855,7 +2295,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List25">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 25">Illustration and other content type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 25">Illustration and other content type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -4038,630 +2478,17 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List26">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 26">Main subject scheme identifier code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>Dewey</xs:documentation>
-					<xs:documentation>Dewey Decimal Classification</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>Abridged Dewey</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>LC classification</xs:documentation>
-					<xs:documentation>US Library of Congress classification</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>LC subject heading</xs:documentation>
-					<xs:documentation>US Library of Congress subject heading</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>NLM classification</xs:documentation>
-					<xs:documentation>US National Library of Medicine medical classification</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>MeSH heading</xs:documentation>
-					<xs:documentation>US National Library of Medicine Medical subject heading</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="07">
-				<xs:annotation>
-					<xs:documentation>NAL subject heading</xs:documentation>
-					<xs:documentation>US National Agricultural Library subject heading</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="08">
-				<xs:annotation>
-					<xs:documentation>AAT</xs:documentation>
-					<xs:documentation>Getty Art and Architecture Thesaurus heading</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="09">
-				<xs:annotation>
-					<xs:documentation>UDC</xs:documentation>
-					<xs:documentation>Universal Decimal Classification</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="10">
-				<xs:annotation>
-					<xs:documentation>BISAC Subject Heading</xs:documentation>
-					<xs:documentation>BISAC Subject Headings are used in the North American market to categorize books based on topical content. They serve as a guideline for shelving books in physical stores and browsing books in online stores. See https://www.bisg.org/complete-bisac-subject-headings-2013-edition</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="11">
-				<xs:annotation>
-					<xs:documentation>BISAC region code</xs:documentation>
-					<xs:documentation>A geographical qualifier used with a BISAC subject category</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="12">
-				<xs:annotation>
-					<xs:documentation>BIC subject category</xs:documentation>
-					<xs:documentation>For all BIC subject codes and qualifiers, see http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="13">
-				<xs:annotation>
-					<xs:documentation>BIC geographical qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="14">
-				<xs:annotation>
-					<xs:documentation>BIC language qualifier (language as subject)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="15">
-				<xs:annotation>
-					<xs:documentation>BIC time period qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="16">
-				<xs:annotation>
-					<xs:documentation>BIC educational purpose qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="17">
-				<xs:annotation>
-					<xs:documentation>BIC reading level and special interest qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="18">
-				<xs:annotation>
-					<xs:documentation>DDC-Sachgruppen der Deutschen Nationalbibliografie</xs:documentation>
-					<xs:documentation>Used for German National Bibliography since 2004 (100 subjects). Is different from value 30. See http://www.d-nb.de/service/pdf/ddc_wv_aktuell.pdf (in German) or http://www.d-nb.de/eng/service/pdf/ddc_wv_aktuell_eng.pdf (English)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="19">
-				<xs:annotation>
-					<xs:documentation>LC fiction genre heading</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="20">
-				<xs:annotation>
-					<xs:documentation>Keywords</xs:documentation>
-					<xs:documentation>For indexing and search purposes, not normally intended for display. Where multiple keywords or keyword phrases are sent in a single instance of the &lt;SubjectHeadingText&gt; element, it is recommended that they should be separated by semi-colons (this is consistent with Library of Congress preferred practice)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="21">
-				<xs:annotation>
-					<xs:documentation>BIC children’s book marketing category</xs:documentation>
-					<xs:documentation>See http://www.bic.org.uk/8/Children’s-Books-Marketing-Classifications/</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="22">
-				<xs:annotation>
-					<xs:documentation>BISAC Merchandising Theme</xs:documentation>
-					<xs:documentation>BISAC Merchandising Themes are used in addition to BISAC Subject Headings to denote an audience to which a work may be of particular appeal, a time of year or event for which a work may be especially appropriate, or to further describe fictional works that have been subject-coded by genre</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="23">
-				<xs:annotation>
-					<xs:documentation>Publisher’s own category code</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="24">
-				<xs:annotation>
-					<xs:documentation>Proprietary subject scheme</xs:documentation>
-					<xs:documentation>As specified in &lt;SubjectSchemeName&gt;</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="25">
-				<xs:annotation>
-					<xs:documentation>Tabla de materias ISBN</xs:documentation>
-					<xs:documentation>Latin America</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="26">
-				<xs:annotation>
-					<xs:documentation>Warengruppen-Systematik des deutschen Buchhandels</xs:documentation>
-					<xs:documentation>See http://info.vlb.de/files/wgsneuversion2_0.pdf (in German)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="27">
-				<xs:annotation>
-					<xs:documentation>SWD</xs:documentation>
-					<xs:documentation>Schlagwortnormdatei – Subject Headings Authority File in the German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/swd.htm (in German) and http://www.d-nb.de/eng/standardisierung/normdateien/swd.htm (English). DEPRECATED in favour of the GND</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="28">
-				<xs:annotation>
-					<xs:documentation>Thèmes Electre</xs:documentation>
-					<xs:documentation>Subject classification used by Electre (France)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="29">
-				<xs:annotation>
-					<xs:documentation>CLIL</xs:documentation>
-					<xs:documentation>France. A four-digit number, see http://www.clil.org/information/documentation.html (in French). The first digit identifies the version of the scheme</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
 			<xs:enumeration value="30">
 				<xs:annotation>
-					<xs:documentation>DNB-Sachgruppen</xs:documentation>
-					<xs:documentation>Deutsche Bibliothek subject groups. Used for German National Bibliography until 2003 (65 subjects). Is different from value 18. See http://www.d-nb.de/service/pdf/ddc_wv_alt_neu.pdf</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="31">
-				<xs:annotation>
-					<xs:documentation>NUGI</xs:documentation>
-					<xs:documentation>Nederlandse Uniforme Genre-Indeling (former Dutch book trade classification)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="32">
-				<xs:annotation>
-					<xs:documentation>NUR</xs:documentation>
-					<xs:documentation>Nederlandstalige Uniforme Rubrieksindeling (Dutch book trade classification, from 2002),see http://www.boek.nl/nur (in Dutch)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="33">
-				<xs:annotation>
-					<xs:documentation>ECPA Christian Book Category</xs:documentation>
-					<xs:documentation>ECPA Christian Product Category Book Codes, consisting of up to three x 3-letter blocks, for Super Category, Primary Category and Sub-Category. See http://www.ecpa.org/ECPA/cbacategories.xls</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="34">
-				<xs:annotation>
-					<xs:documentation>SISO</xs:documentation>
-					<xs:documentation>Schema Indeling Systematische Catalogus Openbare Bibliotheken (Dutch library classification)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="35">
-				<xs:annotation>
-					<xs:documentation>Korean Decimal Classification (KDC)</xs:documentation>
-					<xs:documentation>A modified Dewey Decimal Classification used in the Republic of Korea</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="36">
-				<xs:annotation>
-					<xs:documentation>DDC Deutsch 22</xs:documentation>
-					<xs:documentation>German Translation of Dewey Decimal Classification 22. Also known as DDC 22 ger. See http://www.ddc-deutsch.de/produkte/uebersichten/</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="37">
-				<xs:annotation>
-					<xs:documentation>Bokgrupper</xs:documentation>
-					<xs:documentation>Norwegian book trade product categories (Bokgrupper) administered by the Norwegian Publishers Association (http://www.forleggerforeningen.no/)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="38">
-				<xs:annotation>
-					<xs:documentation>Varegrupper</xs:documentation>
-					<xs:documentation>Norwegian bookselling subject categories (Bokhandelens varegrupper) administered by the Norwegian Booksellers Association (http://bokhandlerforeningen.no/)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="39">
-				<xs:annotation>
-					<xs:documentation>Læreplaner</xs:documentation>
-					<xs:documentation>Norwegian school curriculum version. Deprecated</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="40">
-				<xs:annotation>
-					<xs:documentation>Nippon Decimal Classification</xs:documentation>
-					<xs:documentation>Japanese subject classification scheme</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="41">
-				<xs:annotation>
-					<xs:documentation>BSQ</xs:documentation>
-					<xs:documentation>BookSelling Qualifier: Russian book trade classification</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="42">
-				<xs:annotation>
-					<xs:documentation>ANELE Materias</xs:documentation>
-					<xs:documentation>Spain: subject coding scheme of the Asociación Nacional de Editores de Libros y Material de Enseñanza</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="43">
-				<xs:annotation>
-					<xs:documentation>Utdanningsprogram</xs:documentation>
-					<xs:documentation>Codes for Norwegian ‘utdanningsprogram’ used in secondary education. See: http://www.udir.no/. (Formerly labelled ‘Skolefag’)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="44">
-				<xs:annotation>
-					<xs:documentation>Programområde</xs:documentation>
-					<xs:documentation>Codes for Norwegian ‘programområde’ used in secondary education. See http://www.udir.no/. (Formerly labelled ‘Videregående’ or ‘Programfag’)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="45">
-				<xs:annotation>
-					<xs:documentation>Undervisningsmateriell</xs:documentation>
-					<xs:documentation>Norwegian list of categories for books and other material used in education</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="46">
-				<xs:annotation>
-					<xs:documentation>Norsk DDK</xs:documentation>
-					<xs:documentation>Norwegian version of Dewey Decimal Classification</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="47">
-				<xs:annotation>
-					<xs:documentation>Varugrupper</xs:documentation>
-					<xs:documentation>Swedish bookselling subject categories</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="48">
-				<xs:annotation>
-					<xs:documentation>SAB</xs:documentation>
-					<xs:documentation>Swedish classification scheme</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="49">
-				<xs:annotation>
-					<xs:documentation>Läromedelstyp</xs:documentation>
-					<xs:documentation>Swedish bookselling educational subject type</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="50">
-				<xs:annotation>
-					<xs:documentation>Förhandsbeskrivning</xs:documentation>
-					<xs:documentation>Swedish publishers preliminary subject classification</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="51">
-				<xs:annotation>
-					<xs:documentation>Spanish ISBN UDC subset</xs:documentation>
-					<xs:documentation>Controlled subset of UDC codes used by the Spanish ISBN Agency</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="52">
-				<xs:annotation>
-					<xs:documentation>ECI subject categories</xs:documentation>
-					<xs:documentation>Subject categories defined by El Corte Inglés and used widely in the Spanish book trade</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="53">
-				<xs:annotation>
-					<xs:documentation>Soggetto CCE</xs:documentation>
-					<xs:documentation>Classificazione commerciale editoriale (Italian book trade subject category based on BIC). CCE documentation available at http://www.ie-online.it/CCE2_2.0.pdf</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="54">
-				<xs:annotation>
-					<xs:documentation>Qualificatore geografico CCE</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="55">
-				<xs:annotation>
-					<xs:documentation>Qualificatore di lingua CCE</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="56">
-				<xs:annotation>
-					<xs:documentation>Qualificatore di periodo storico CCE</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="57">
-				<xs:annotation>
-					<xs:documentation>Qualificatore di livello scolastico CCE</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="58">
-				<xs:annotation>
-					<xs:documentation>Qualificatore di età di lettura CCE</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="59">
-				<xs:annotation>
-					<xs:documentation>VdS Bildungsmedien Fächer</xs:documentation>
-					<xs:documentation>Subject code list of the German association of educational media publishers</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="60">
-				<xs:annotation>
-					<xs:documentation>Fagkoder</xs:documentation>
-					<xs:documentation>Norwegian primary and secondary school subject categories (fagkoder), see http://www.udir.no/</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="61">
-				<xs:annotation>
-					<xs:documentation>JEL classification</xs:documentation>
-					<xs:documentation>Journal of Economic Literature classification scheme</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="62">
-				<xs:annotation>
-					<xs:documentation>CSH</xs:documentation>
-					<xs:documentation>National Library of Canada subject heading (English)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="63">
-				<xs:annotation>
-					<xs:documentation>RVM</xs:documentation>
-					<xs:documentation>Répertoire de vedettes-matière (Bibliothèque de l’Université Laval) (French)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="64">
-				<xs:annotation>
-					<xs:documentation>YSA</xs:documentation>
-					<xs:documentation>Yleinen suomalainen asiasanasto: Finnish General Thesaurus. See http://onki.fi/fi/browser/ (in Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="65">
-				<xs:annotation>
-					<xs:documentation>Allärs</xs:documentation>
-					<xs:documentation>Allmän tesaurus på svenska: Swedish translation of the Finnish General Thesaurus. See http://onki.fi/fi/browser/ (in Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="66">
-				<xs:annotation>
-					<xs:documentation>YKL</xs:documentation>
-					<xs:documentation>Yleisten kirjastojen luokitusjärjestelmä: Finnish Public Libraries Classification System. See http://ykl.kirjastot.fi/ (in Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="67">
-				<xs:annotation>
-					<xs:documentation>MUSA</xs:documentation>
-					<xs:documentation>Musiikin asiasanasto: Finnish Music Thesaurus. See http://onki.fi/fi/browser/ (in Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="68">
-				<xs:annotation>
-					<xs:documentation>CILLA</xs:documentation>
-					<xs:documentation>Specialtesaurus för musik: Swedish translation of the Finnish Music Thesaurus. See http://onki.fi/fi/browser/ (in Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="69">
-				<xs:annotation>
-					<xs:documentation>Kaunokki</xs:documentation>
-					<xs:documentation>Fiktiivisen aineiston asiasanasto: Finnish thesaurus for fiction. See http://kaunokki.kirjastot.fi/ (in Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="70">
-				<xs:annotation>
-					<xs:documentation>Bella</xs:documentation>
-					<xs:documentation>Specialtesaurus för fiktivt material: Swedish translation of the Finnish thesaurus for fiction. See http://kaunokki.kirjastot.fi/sv-FI/ (in Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="71">
-				<xs:annotation>
-					<xs:documentation>YSO</xs:documentation>
-					<xs:documentation>Yleinen suomalainen ontologia: Finnish General Upper Ontology. See http://onki.fi/fi/browser/ (In Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="72">
-				<xs:annotation>
-					<xs:documentation>Paikkatieto ontologia</xs:documentation>
-					<xs:documentation>Finnish Place Ontology. See http://onki.fi/fi/browser/ (in Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="73">
-				<xs:annotation>
-					<xs:documentation>Suomalainen kirja-alan luokitus</xs:documentation>
-					<xs:documentation>Finnish book trade categorisation</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="74">
-				<xs:annotation>
-					<xs:documentation>Sears</xs:documentation>
-					<xs:documentation>Sears List of Subject Headings</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="75">
-				<xs:annotation>
-					<xs:documentation>BIC E4L</xs:documentation>
-					<xs:documentation>BIC E4Libraries Category Headings, see http://www.bic.org.uk/51/E4libraries-Subject-Category-Headings/</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="76">
-				<xs:annotation>
-					<xs:documentation>CSR</xs:documentation>
-					<xs:documentation>Code Sujet Rayon: subject categories used by bookstores in France</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="77">
-				<xs:annotation>
-					<xs:documentation>Suomalainen oppiaineluokitus</xs:documentation>
-					<xs:documentation>Finnish school subject categories</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="78">
-				<xs:annotation>
-					<xs:documentation>Japanese book trade C-Code</xs:documentation>
-					<xs:documentation>See http://www.asahi-net.or.jp/~ax2s-kmtn/ref/ccode.html (in Japanese)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="79">
-				<xs:annotation>
-					<xs:documentation>Japanese book trade Genre Code</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="80">
-				<xs:annotation>
-					<xs:documentation>Fiktiivisen aineiston lisäluokitus</xs:documentation>
-					<xs:documentation>Finnish fiction genre classification. See http://ykl.kirjastot.fi/fi-FI/lisaluokat/ (in Finnish)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="85">
-				<xs:annotation>
-					<xs:documentation>Postal code</xs:documentation>
-					<xs:documentation>Location defined by postal code. Format is two-letter country code (from List 91), space, postal code. Note some postal codes themselves contain spaces, eg ‘GB N7 9DP’ or ‘US 10125’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="86">
-				<xs:annotation>
-					<xs:documentation>GeoNames ID</xs:documentation>
-					<xs:documentation>ID number for geographical place, as defined at http://www.geonames.org (eg 2825297 is Stuttgart, Germany, see http://www.geonames.org/2825297)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="87">
-				<xs:annotation>
-					<xs:documentation>NewBooks Subject Classification</xs:documentation>
-					<xs:documentation>Used for classification of academic and specialist publication in German-speaking countries. See http://www.newbooks-services.com/de/top/unternehmensportrait/klassifikation-und-mapping.html (German) and http://www.newbooks-services.com/en/top/about-newbooks/classification-mapping.html (English)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="91">
-				<xs:annotation>
-					<xs:documentation>GND</xs:documentation>
-					<xs:documentation>Gemeinsame Normdatei – Joint Authority File in the German-speaking countries. See http://www.dnb.de/EN/gnd (English). Combines the PND, SWD and GKD into a single authority file, and should be used in preference to the older codes</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="92">
-				<xs:annotation>
-					<xs:documentation>BIC UKSLC</xs:documentation>
-					<xs:documentation>UK Standard Library Categories, the successor to BIC’s E4L classification scheme</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="93">
-				<xs:annotation>
-					<xs:documentation>Thema subject category</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="94">
-				<xs:annotation>
-					<xs:documentation>Thema geographical qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="95">
-				<xs:annotation>
-					<xs:documentation>Thema language qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="96">
-				<xs:annotation>
-					<xs:documentation>Thema time period qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="97">
-				<xs:annotation>
-					<xs:documentation>Thema educational purpose qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="98">
-				<xs:annotation>
-					<xs:documentation>Thema interest age / special interest qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="99">
-				<xs:annotation>
-					<xs:documentation>Thema style qualifier</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A2">
-				<xs:annotation>
-					<xs:documentation>Ämnesord</xs:documentation>
-					<xs:documentation>Swedish subject categories maintained by Bokrondellen</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A3">
-				<xs:annotation>
-					<xs:documentation>Statystyka Książek Papierowych, Mówionych I Elektronicznych</xs:documentation>
-					<xs:documentation>Polish Statistical Book and E-book Classification</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A4">
-				<xs:annotation>
-					<xs:documentation>CCSS</xs:documentation>
-					<xs:documentation>Common Core State Standards curriculum alignment, for links to US educational standards. &lt;SubjectCode&gt; uses the full dot notation. See http://www.corestandards.org/developers-and-publishers</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A5">
-				<xs:annotation>
-					<xs:documentation>Rameau</xs:documentation>
-					<xs:documentation>French library subject headings</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A6">
-				<xs:annotation>
-					<xs:documentation>Nomenclature discipline scolaire</xs:documentation>
-					<xs:documentation>French educational subject classification scolomfr-voc-015, used for example on WizWiz.fr. See http://www.lom-fr.fr/scolomfr/vocabulaires/consultation-des-vocabulaires.html</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A7">
-				<xs:annotation>
-					<xs:documentation>ISIC</xs:documentation>
-					<xs:documentation>International Standard Industry Classification, a classification of economic activities. Use for books that are about a particular industry or economic activity. &lt;SubjectCode&gt; should be a single letter denoting an ISIC section OR a 2-, 3- or 4-digit number denoting an ISIC division, group or class. See http://unstats.un.org/unsd/cr/registry/isic-4.asp</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A8">
-				<xs:annotation>
-					<xs:documentation>LC Children’s Subject Headings</xs:documentation>
-					<xs:documentation>Library of Congress Children’s Subject Headings: LCSHAC supplementary headings for Children’s books</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A9">
-				<xs:annotation>
-					<xs:documentation>Ny Läromedel</xs:documentation>
-					<xs:documentation>Swedish bookselling educational subject</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B0">
-				<xs:annotation>
-					<xs:documentation>EuroVoc</xs:documentation>
-					<xs:documentation>EuroVoc multilingual thesaurus. &lt;SubjectCode&gt; should be a EuroVoc concept dc:identifier (for example, 2777, ‘Refrigerated products’). See http://eurovoc.europa.eu</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B1">
-				<xs:annotation>
-					<xs:documentation>BISG Educational Taxonomy</xs:documentation>
-					<xs:documentation>Controlled vocabulary for educational objectives. See https://www.bisg.org/educational-taxonomy</xs:documentation>
+					<xs:documentation>Table of contents</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List27">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 27">Subject scheme identifier code</xs:documentation>
+			<xs:documentation source="ONIX Code List 27">Subject scheme identifier</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -4721,12 +2548,12 @@
 			<xs:enumeration value="10">
 				<xs:annotation>
 					<xs:documentation>BISAC Subject Heading</xs:documentation>
-					<xs:documentation>BISAC Subject Headings are used in the North American market to categorize books based on topical content. They serve as a guideline for shelving books in physical stores and browsing books in online stores. See https://www.bisg.org/complete-bisac-subject-headings-2014-edition</xs:documentation>
+					<xs:documentation>BISAC Subject Headings are used in the North American market to categorize books based on topical content. They serve as a guideline for shelving books in physical stores and browsing books in online stores. See https://bisg.org/page/BISACSubjectCodes</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="11">
 				<xs:annotation>
-					<xs:documentation>BISAC region code</xs:documentation>
+					<xs:documentation>BISAC Regional theme</xs:documentation>
 					<xs:documentation>A geographical qualifier used with a BISAC subject category</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
@@ -4781,13 +2608,13 @@
 			<xs:enumeration value="20">
 				<xs:annotation>
 					<xs:documentation>Keywords</xs:documentation>
-					<xs:documentation>For indexing and search purposes, not normally intended for display. Where multiple keywords or keyword phrases are sent in a single instance of the &lt;SubjectHeadingText&gt; element, it is recommended that they should be separated by semi-colons (this is consistent with Library of Congress preferred practice)</xs:documentation>
+					<xs:documentation>For indexing and search purposes, not normally intended for display. Where multiple keywords or keyword phrases are sent, this should be in a single instance of the &lt;SubjectHeadingText&gt; element, and it is recommended that they should be separated by semi-colons (this is consistent with Library of Congress preferred practice)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="21">
 				<xs:annotation>
 					<xs:documentation>BIC children’s book marketing category</xs:documentation>
-					<xs:documentation>See http://www.bic.org.uk/8/Children’s-Books-Marketing-Classifications/</xs:documentation>
+					<xs:documentation>See PA/BIC CBMC guidelines at http://www.bic.org.uk/8/Children%27s-Books-Marketing-Classifications/</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="22">
@@ -4823,7 +2650,7 @@
 			<xs:enumeration value="27">
 				<xs:annotation>
 					<xs:documentation>SWD</xs:documentation>
-					<xs:documentation>Schlagwortnormdatei – Subject Headings Authority File in the German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/swd.htm (in German) and http://www.d-nb.de/eng/standardisierung/normdateien/swd.htm (English). DEPRECATED in favour of the GND</xs:documentation>
+					<xs:documentation>Schlagwortnormdatei – Subject Headings Authority File in the German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/swd.htm (in German) and http://www.d-nb.de/eng/standardisierung/normdateien/swd.htm (English). DEPRECATED in favor of the GND</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="28">
@@ -5039,7 +2866,7 @@
 			<xs:enumeration value="63">
 				<xs:annotation>
 					<xs:documentation>RVM</xs:documentation>
-					<xs:documentation>Répertoire de vedettes-matière (Bibliothèque de l’Université Laval) (French)</xs:documentation>
+					<xs:documentation>Répertoire de vedettes-matière Bibliothèque de l’Université Laval) (French)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="64">
@@ -5219,12 +3046,12 @@
 			<xs:enumeration value="93">
 				<xs:annotation>
 					<xs:documentation>Thema subject category</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>International multilingual subject category scheme – see https://ns.editeur.org/thema</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="94">
 				<xs:annotation>
-					<xs:documentation>Thema geographical qualifier</xs:documentation>
+					<xs:documentation>Thema place qualifier</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
@@ -5285,7 +3112,7 @@
 			<xs:enumeration value="A6">
 				<xs:annotation>
 					<xs:documentation>Nomenclature discipline scolaire</xs:documentation>
-					<xs:documentation>French educational subject classification scolomfr-voc-015, used for example on WizWiz.fr. See http://www.lom-fr.fr/scolomfr/vocabulaires/consultation-des-vocabulaires.html</xs:documentation>
+					<xs:documentation>French educational subject classification scolomfr-voc-015. See https://www.reseau-canope.fr/scolomfr/accueil.html</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="A7">
@@ -5321,20 +3148,32 @@
 			<xs:enumeration value="B2">
 				<xs:annotation>
 					<xs:documentation>Keywords (not for display)</xs:documentation>
-					<xs:documentation>For indexing and search purposes, MUST not be displayed. Where multiple keywords or keyword phrases are sent in a single instance of the &lt;SubjectHeadingText&gt; element, it is recommended that they should be separated by semi-colons. Use code B2 in preference to code 20 where it is important to show the keyword list is specifically NOT for display to purchasers</xs:documentation>
+					<xs:documentation>For indexing and search purposes, MUST not be displayed. Where multiple keywords or keyword phrases are sent, this should be in a single instance of the &lt;SubjectHeadingText&gt; element, and it is recommended that they should be separated by semi-colons. Use of code B2 should be very rare: use B2 in preference to code 20 only where it is important to show the keyword list is specifically NOT for display to purchasers (eg some keywords for a medical textbook may appear offensive if displayed out of context)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B3">
 				<xs:annotation>
 					<xs:documentation>Nomenclature Diplôme</xs:documentation>
-					<xs:documentation>French higher and vocational educational subject classification scolomfr-voc-29 subject category for degree and diploma study. See http://www.lom-fr.fr/scolomfr/vocabulaires/consultation-des-vocabulaires.html</xs:documentation>
+					<xs:documentation>French higher and vocational educational subject classification scolomfr-voc-29 subject category for degree and diploma study. See https://www.reseau-canope.fr/scolomfr/accueil.html</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B4">
+				<xs:annotation>
+					<xs:documentation>Key character names</xs:documentation>
+					<xs:documentation>For fiction and non-fiction, one or more key names, provided – like keywords – for indexing and search purposes. Where multiple character names are sent, this should be in a single instance of &lt;SubjectHeadingText&gt;, and multiple names should be separated by semi-colons. Note &lt;NameAsSubject&gt; should be used for people who are the central subject of the book. Code B4 may be used for names of lesser importance</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B5">
+				<xs:annotation>
+					<xs:documentation>Key place names</xs:documentation>
+					<xs:documentation>For fiction and non-fiction, one or more key names, provded – like keywords – for indexing and search purposes. Where multiple place names are sent, this should in a single instance of &lt;SubjectHeadingText&gt;, and multiple names should be separated by semi-colons. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List28">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 28">Audience code</xs:documentation>
+			<xs:documentation source="ONIX Code List 28">Audience type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -5532,8 +3371,8 @@
 			</xs:enumeration>
 			<xs:enumeration value="23">
 				<xs:annotation>
-					<xs:documentation>Common European Framework for Language Learning</xs:documentation>
-					<xs:documentation>Codes A1 to C2 indicating standardised level of language learning or teaching material, from beginner to advanced, used in EU</xs:documentation>
+					<xs:documentation>Common European Framework of Reference for Language Learning (CEFR)</xs:documentation>
+					<xs:documentation>Codes A1 to C2 indicating standardised level of language learning or teaching material, from beginner to advanced, defined by the Council of Europe (see http://www.coe.int/lang-CEFR)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="24">
@@ -5684,7 +3523,13 @@
 			<xs:enumeration value="30">
 				<xs:annotation>
 					<xs:documentation>Nomenclature niveaux</xs:documentation>
-					<xs:documentation>French educational level classification scolomfr-voc-022, used for example on WizWiz.fr. See http://www.lom-fr.fr/scolomfr/vocabulaires/consultation-des-vocabulaires.html</xs:documentation>
+					<xs:documentation>French educational level classification scolomfr-voc-022. See https://www.reseau-canope.fr/scolomfr/accueil.html</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Brazil Education level</xs:documentation>
+					<xs:documentation>Nível de Educação do Brasil, see List 238. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -5716,7 +3561,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List32">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 32">Complexity scheme identifier code</xs:documentation>
+			<xs:documentation source="ONIX Code List 32">Complexity scheme identifier</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -5734,7 +3579,7 @@
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>Fry Readability score</xs:documentation>
-					<xs:documentation>Fry readability metric based on number of sentences and syllables per 100 words. Expressed as a number from 1 to 15 in &lt;ComplexityCode&gt;</xs:documentation>
+					<xs:documentation>Fry readability metric based on number of sentences and syllables per 100 words. Expressed as an integer from 1 to 15 in &lt;ComplexityCode&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="04">
@@ -5764,7 +3609,7 @@
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Flesch-Kincaid Grade Level</xs:documentation>
-					<xs:documentation>Flesch-Kincaid Grade Level Formula, a standard readability measure based on the weighted number of syllables per word and words per sentence. &lt;ComplexityCode&gt; is a real number between about -1 and 20</xs:documentation>
+					<xs:documentation>Flesch-Kincaid Grade Level Formula, a standard readability measure based on the weighted number of syllables per word and words per sentence. &lt;ComplexityCode&gt; is a real number typically between about -1 and 20</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
@@ -5781,306 +3626,11 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="List33">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 33">Other text type code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>Main description</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>Short description/annotation</xs:documentation>
-					<xs:documentation>Limited to a maximum of 350 characters</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>Long description</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>Table of contents</xs:documentation>
-					<xs:documentation>Used for a table of contents sent as a single text field, which may or may not carry structure expressed through HTML etc. Alternatively, a fully structured table of contents may be sent by using the &lt;ContentItem&gt; composite</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>Review quote, restricted length</xs:documentation>
-					<xs:documentation>A review quote that is restricted to a maximum length agreed between the sender and receiver of an ONIX file</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>Quote from review of previous edition</xs:documentation>
-					<xs:documentation>A review quote taken from a review of a previous edition of the work</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="07">
-				<xs:annotation>
-					<xs:documentation>Review text</xs:documentation>
-					<xs:documentation>Full text of a review of the product</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="08">
-				<xs:annotation>
-					<xs:documentation>Review quote</xs:documentation>
-					<xs:documentation>A quote from a review of the product</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="09">
-				<xs:annotation>
-					<xs:documentation>Promotional ‘headline’</xs:documentation>
-					<xs:documentation>A promotional phrase which is intended to headline a description of the product</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="10">
-				<xs:annotation>
-					<xs:documentation>Previous review quote</xs:documentation>
-					<xs:documentation>A quote from a review of a previous work by the same author(s) or in the same series</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="11">
-				<xs:annotation>
-					<xs:documentation>Author comments</xs:documentation>
-					<xs:documentation>May be part of Reading Group Guide material: for other commentary, see code 42</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="12">
-				<xs:annotation>
-					<xs:documentation>Description for reader</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="13">
-				<xs:annotation>
-					<xs:documentation>Biographical note</xs:documentation>
-					<xs:documentation>A note referring to all contributors to a product – NOT linked to a single contributor</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="14">
-				<xs:annotation>
-					<xs:documentation>Description for Reading Group Guide</xs:documentation>
-					<xs:documentation>For linking to a complete Reading Group Guide, see code 41</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="15">
-				<xs:annotation>
-					<xs:documentation>Discussion question for Reading Group Guide</xs:documentation>
-					<xs:documentation>Each instance must carry a single question: for linking to a complete Reading Group Guide, see code 41</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="16">
-				<xs:annotation>
-					<xs:documentation>Competing titles</xs:documentation>
-					<xs:documentation>Free text listing of other titles with which the product is in competition: although this text might not appear in ‘public’ ONIX records, it could be required where ONIX Is used as a communication format within a group of publishing and distribution companies</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="17">
-				<xs:annotation>
-					<xs:documentation>Flap copy</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="18">
-				<xs:annotation>
-					<xs:documentation>Back cover copy</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="19">
-				<xs:annotation>
-					<xs:documentation>Feature</xs:documentation>
-					<xs:documentation>Text describing a feature of a product to which the publisher wishes to draw attention for promotional purposes. Each separate feature should be described by a separate repeat, so that formatting can be applied at the discretion of the receiver of the ONIX record</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="20">
-				<xs:annotation>
-					<xs:documentation>New feature</xs:documentation>
-					<xs:documentation>As code 19, but used for a feature which is new in a new edition of the product</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="21">
-				<xs:annotation>
-					<xs:documentation>Publisher’s notice</xs:documentation>
-					<xs:documentation>A statement included by a publisher in fulfillment of its contractual obligations, such as a disclaimer, sponsor statement, or legal notice of any sort. Note that the inclusion of such a notice cannot and does not imply that a user of the ONIX record is obliged to reproduce it</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="22">
-				<xs:annotation>
-					<xs:documentation>Index</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="23">
-				<xs:annotation>
-					<xs:documentation>Excerpt from book</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="24">
-				<xs:annotation>
-					<xs:documentation>First chapter</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="25">
-				<xs:annotation>
-					<xs:documentation>Description for sales people</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="26">
-				<xs:annotation>
-					<xs:documentation>Description for press or other media</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="27">
-				<xs:annotation>
-					<xs:documentation>Description for subsidiary rights department</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="28">
-				<xs:annotation>
-					<xs:documentation>Description for teachers/educators</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="30">
-				<xs:annotation>
-					<xs:documentation>Unpublished endorsement</xs:documentation>
-					<xs:documentation>A quote usually provided by a celebrity to promote a new book, not from a review</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="31">
-				<xs:annotation>
-					<xs:documentation>Description for bookstore</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="32">
-				<xs:annotation>
-					<xs:documentation>Description for library</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="33">
-				<xs:annotation>
-					<xs:documentation>Introduction or preface</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="34">
-				<xs:annotation>
-					<xs:documentation>Full text</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="35">
-				<xs:annotation>
-					<xs:documentation>Promotional text</xs:documentation>
-					<xs:documentation>Promotional text not covered elsewhere</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="40">
-				<xs:annotation>
-					<xs:documentation>Author interview / QandA</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="41">
-				<xs:annotation>
-					<xs:documentation>Reading Group Guide</xs:documentation>
-					<xs:documentation>Complete guide: see also codes 14 and 15</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="42">
-				<xs:annotation>
-					<xs:documentation>Commentary / discussion</xs:documentation>
-					<xs:documentation>Other than author comments: see code 11</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="43">
-				<xs:annotation>
-					<xs:documentation>Short description for series or set</xs:documentation>
-					<xs:documentation>(of which the product is a part.) Limited to a maximum of 350 characters</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="44">
-				<xs:annotation>
-					<xs:documentation>Long description for series or set</xs:documentation>
-					<xs:documentation>(of which the product is a part)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="45">
-				<xs:annotation>
-					<xs:documentation>Contributor event schedule</xs:documentation>
-					<xs:documentation>Link to a schedule in iCalendar format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="46">
-				<xs:annotation>
-					<xs:documentation>License</xs:documentation>
-					<xs:documentation>Link to a license covering permitted usage of the product content</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="47">
-				<xs:annotation>
-					<xs:documentation>Open access statement</xs:documentation>
-					<xs:documentation>Short summary statement of open access status and any related conditions (eg ‘Open access – no commercial use’), primarily for marketing purposes. Should always be accompanied by a link to the complete license (see code 46)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="48">
-				<xs:annotation>
-					<xs:documentation>Digital exclusivity statement</xs:documentation>
-					<xs:documentation>Short summary statement that the product is available only in digital formats (eg ‘Digital exclusive’). If a non-digital version is planned, an &lt;EndDate&gt; should be used to specify the date when exclusivity will end. If a non-digital version is available, the statement should not be included</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="49">
-				<xs:annotation>
-					<xs:documentation>Official recommendation</xs:documentation>
-					<xs:documentation>For example a recommendation or approval provided by a ministry of education or other official body. Use &lt;Text&gt; to provide details and &lt;TextSourceCorporate&gt; to name the approver</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="98">
-				<xs:annotation>
-					<xs:documentation>Master brand name</xs:documentation>
-					<xs:documentation>A master brand name or title, where the use of the brand spans multiple sets, series and product forms, and possibly multiple imprints and publishers. Used only for branded media properties carrying, for example, a children’s character brand. (This functionality is provided as a workaround in ONIX 2.1 only. ONIX 3.0 has specific provision for master brands as title elements</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="99">
-				<xs:annotation>
-					<xs:documentation>Country of final manufacture</xs:documentation>
-					<xs:documentation>A single ISO 3166-1 country code from List 91 designating the country of final manufacture of the product. (This functionality is provided as a workaround in ONIX 2.1. ONIX 3.0 has specific provision for country of manufacture as a separate element)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="List34">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 34">Text format code</xs:documentation>
+			<xs:documentation source="ONIX Code List 34">Text format</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="00">
-				<xs:annotation>
-					<xs:documentation>ASCII text</xs:documentation>
-					<xs:documentation>DEPRECATED: use code 06 or 07 as appropriate</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>SGML</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>HTML</xs:documentation>
@@ -6091,12 +3641,6 @@
 				<xs:annotation>
 					<xs:documentation>XML</xs:documentation>
 					<xs:documentation>Other than XHTML</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>PDF</xs:documentation>
-					<xs:documentation>DEPRECATED: was formerly assigned both to PDF and to XHTML</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
@@ -6114,584 +3658,14 @@
 			<xs:enumeration value="07">
 				<xs:annotation>
 					<xs:documentation>Basic ASCII text</xs:documentation>
-					<xs:documentation>Plain text containing no tags of any kind, except for the tags &amp;amp; and &amp;lt; that XML insists must be used to represent ampersand and less-than characters in text, and with the character set limited to the ASCII range, i.e. valid UTF-8 characters whose character number lies between 32 (space) and 126 (tilde)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="08">
-				<xs:annotation>
-					<xs:documentation>PDF</xs:documentation>
-					<xs:documentation>Replaces 04 for the &lt;TextFormat&gt; element, but cannot of course be used as a textformat attribute</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="09">
-				<xs:annotation>
-					<xs:documentation>Microsoft rich text format (RTF)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="10">
-				<xs:annotation>
-					<xs:documentation>Microsoft Word binary format (DOC)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="11">
-				<xs:annotation>
-					<xs:documentation>ECMA 376 WordprocessingML</xs:documentation>
-					<xs:documentation>Office Open XML file format / OOXML / DOCX</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="12">
-				<xs:annotation>
-					<xs:documentation>ISO 26300 ODF</xs:documentation>
-					<xs:documentation>ISO Open Document Format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="13">
-				<xs:annotation>
-					<xs:documentation>Corel Wordperfect binary format (DOC)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="14">
-				<xs:annotation>
-					<xs:documentation>EPUB</xs:documentation>
-					<xs:documentation>The Open Publication Structure / OPS Container Format standard of the International Digital Publishing Forum (IDPF) [File extension .epub]</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="15">
-				<xs:annotation>
-					<xs:documentation>XPS</xs:documentation>
-					<xs:documentation>XML Paper Specification</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List35">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 35">Text link type code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>URL</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>DOI</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>PURL</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>URN</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>FTP address</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>filename</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List36">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 36">Front cover image file format code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>GIF</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>JPEG</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>TIF</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List37">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 37">Front cover image file link type code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>URL</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>DOI</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>PURL</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>URN</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>FTP address</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>filename</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List38">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 38">Image/audio/video file type code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>Whole product</xs:documentation>
-					<xs:documentation>Link to a location where the whole product may be found – used for epublications</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>Application: software demo</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>Image: whole cover</xs:documentation>
-					<xs:documentation>Includes cover, back cover, spine and – where appropriate – any flaps. Quality unspecified: if sending both a standard quality and a high quality image, use 03 for standard quality and 05 for high quality</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>Image: front cover</xs:documentation>
-					<xs:documentation>Quality unspecified: if sending both a standard quality and a high quality image, use 04 for standard quality and 06 for high quality</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>Image: whole cover, high quality</xs:documentation>
-					<xs:documentation>Should have a minimum resolution of 300 dpi when rendered at the intended size for display or print</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>Image: front cover, high quality</xs:documentation>
-					<xs:documentation>Should have a minimum resolution of 300 dpi when rendered at the intended size for display or print</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="07">
-				<xs:annotation>
-					<xs:documentation>Image: front cover thumbnail</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="08">
-				<xs:annotation>
-					<xs:documentation>Image: contributor(s)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="10">
-				<xs:annotation>
-					<xs:documentation>Image: for series</xs:documentation>
-					<xs:documentation>Use for an image, other than a logo, that is part of the ‘branding’ of a series</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="11">
-				<xs:annotation>
-					<xs:documentation>Image: series logo</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="12">
-				<xs:annotation>
-					<xs:documentation>Image: product logo</xs:documentation>
-					<xs:documentation>Use only for a logo which is specific to an individual product</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="16">
-				<xs:annotation>
-					<xs:documentation>Image: Master brand logo</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="17">
-				<xs:annotation>
-					<xs:documentation>Image: publisher logo</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="18">
-				<xs:annotation>
-					<xs:documentation>Image: imprint logo</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="22">
-				<xs:annotation>
-					<xs:documentation>Image: table of contents</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="23">
-				<xs:annotation>
-					<xs:documentation>Image: sample content</xs:documentation>
-					<xs:documentation>Use for inside page image for book, or screenshot for software or game (revised definition from Issue 8)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="24">
-				<xs:annotation>
-					<xs:documentation>Image: back cover</xs:documentation>
-					<xs:documentation>Quality unspecified: if sending both a standard quality and a high quality image, use 24 for standard quality and 25 for high quality</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="25">
-				<xs:annotation>
-					<xs:documentation>Image: back cover, high quality</xs:documentation>
-					<xs:documentation>Should have a minimum resolution of 300 dpi when rendered at the intended size for display or print</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="26">
-				<xs:annotation>
-					<xs:documentation>Image: back cover thumbnail</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="27">
-				<xs:annotation>
-					<xs:documentation>Image: other cover material</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="28">
-				<xs:annotation>
-					<xs:documentation>Image: promotional material</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="29">
-				<xs:annotation>
-					<xs:documentation>Video segment: unspecified</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="30">
-				<xs:annotation>
-					<xs:documentation>Audio segment: unspecified</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="31">
-				<xs:annotation>
-					<xs:documentation>Video: author presentation / commentary</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="32">
-				<xs:annotation>
-					<xs:documentation>Video: author interview</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="33">
-				<xs:annotation>
-					<xs:documentation>Video: author reading</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="34">
-				<xs:annotation>
-					<xs:documentation>Video: cover material</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="35">
-				<xs:annotation>
-					<xs:documentation>Video: sample content</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="36">
-				<xs:annotation>
-					<xs:documentation>Video: promotional material</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="37">
-				<xs:annotation>
-					<xs:documentation>Video: review</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="38">
-				<xs:annotation>
-					<xs:documentation>Video: other commentary / discussion</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="41">
-				<xs:annotation>
-					<xs:documentation>Audio: author presentation / commentary</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="42">
-				<xs:annotation>
-					<xs:documentation>Audio: author interview</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="43">
-				<xs:annotation>
-					<xs:documentation>Audio: author reading</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="44">
-				<xs:annotation>
-					<xs:documentation>Audio: sample content</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="45">
-				<xs:annotation>
-					<xs:documentation>Audio: promotional material</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="46">
-				<xs:annotation>
-					<xs:documentation>Audio: review</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="47">
-				<xs:annotation>
-					<xs:documentation>Audio: other commentary / discussion</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="51">
-				<xs:annotation>
-					<xs:documentation>Application: sample content</xs:documentation>
-					<xs:documentation>Use for ‘look inside’ facility or ‘widget’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="52">
-				<xs:annotation>
-					<xs:documentation>Application: promotional material</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List39">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 39">Image/audio/video file format code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>GIF</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>JPEG</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>PDF</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>TIF</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>RealAudio 28.8</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="07">
-				<xs:annotation>
-					<xs:documentation>MP3</xs:documentation>
-					<xs:documentation>MPEG-1/2 Audio Layer III file (.mp3)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="08">
-				<xs:annotation>
-					<xs:documentation>MPEG-4</xs:documentation>
-					<xs:documentation>MPEG-4 container format (.mp4, .m4a)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="09">
-				<xs:annotation>
-					<xs:documentation>PNG</xs:documentation>
-					<xs:documentation>Portable Network Graphics bitmapped image format (.png)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="10">
-				<xs:annotation>
-					<xs:documentation>WMA</xs:documentation>
-					<xs:documentation>Windows Media Audio format (.wma)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="11">
-				<xs:annotation>
-					<xs:documentation>AAC</xs:documentation>
-					<xs:documentation>Advanced Audio Codec format (.aac)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="12">
-				<xs:annotation>
-					<xs:documentation>WAV</xs:documentation>
-					<xs:documentation>Waveform audio file (.wav)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="13">
-				<xs:annotation>
-					<xs:documentation>AIFF</xs:documentation>
-					<xs:documentation>Audio Interchange File Format (.aiff)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="14">
-				<xs:annotation>
-					<xs:documentation>WMV</xs:documentation>
-					<xs:documentation>Windows Media Video format (.wmv)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="15">
-				<xs:annotation>
-					<xs:documentation>OGG</xs:documentation>
-					<xs:documentation>Ogg container format (.ogg)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="16">
-				<xs:annotation>
-					<xs:documentation>AVI</xs:documentation>
-					<xs:documentation>Audio Video Interleaved container format (.avi)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="17">
-				<xs:annotation>
-					<xs:documentation>MOV</xs:documentation>
-					<xs:documentation>Quicktime container format (.mov)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="18">
-				<xs:annotation>
-					<xs:documentation>Flash</xs:documentation>
-					<xs:documentation>Flash container format (includes .flv, .swf, .f4v etc)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="19">
-				<xs:annotation>
-					<xs:documentation>3GP</xs:documentation>
-					<xs:documentation>3GP container format (.3gp, 3g2)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="20">
-				<xs:annotation>
-					<xs:documentation>WebM</xs:documentation>
-					<xs:documentation>WebM container format (includes .webm and .mkv)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List40">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 40">Image/audio/video file link type</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>URL</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>DOI</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>PURL</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>URN</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>FTP address</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>filename</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Plain text containing no tags of any kind, except for the tags &amp;amp; and &amp;lt; that XML insists must be used to represent ampersand and less-than characters in text, and with the character set limited to the ASCII range, i.e. valid characters whose Unicode character number lies between 32 (space) and 126 (tilde)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List41">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 41">Prize or award achievement code</xs:documentation>
+			<xs:documentation source="ONIX Code List 41">Prize or award achievement</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -6740,7 +3714,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List42">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 42">Text item type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 42">Text item type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -6767,83 +3741,11 @@
 					<xs:documentation>Text components such as Index which appear after the main body of text in a product</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="10">
-				<xs:annotation>
-					<xs:documentation>Serial item, miscellaneous or unspecified</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="11">
-				<xs:annotation>
-					<xs:documentation>Research article</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="12">
-				<xs:annotation>
-					<xs:documentation>Review article</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="13">
-				<xs:annotation>
-					<xs:documentation>Letter</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="14">
-				<xs:annotation>
-					<xs:documentation>Short communication</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="15">
-				<xs:annotation>
-					<xs:documentation>Erratum</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="16">
-				<xs:annotation>
-					<xs:documentation>Abstract</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="17">
-				<xs:annotation>
-					<xs:documentation>Book review (or review of other publication)</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="18">
-				<xs:annotation>
-					<xs:documentation>Editorial</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="19">
-				<xs:annotation>
-					<xs:documentation>Product review</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="20">
-				<xs:annotation>
-					<xs:documentation>Index</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="21">
-				<xs:annotation>
-					<xs:documentation>Obituary</xs:documentation>
-					<xs:documentation>For journals</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List43">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 43">Text item identifier type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 43">Text item identifier type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -6892,7 +3794,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List44">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 44">Name code type</xs:documentation>
+			<xs:documentation source="ONIX Code List 44">Name identifier type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -6964,13 +3866,13 @@
 			<xs:enumeration value="16">
 				<xs:annotation>
 					<xs:documentation>ISNI</xs:documentation>
-					<xs:documentation>International Standard Name Identifier. See http://www.isni.org/</xs:documentation>
+					<xs:documentation>International Standard Name Identifier. A sixteen digit number. Usually presented with spaces or hyphens dividing the number into four groups of four digits, but in ONIX the spaces or hyphens should be omitted. See http://www.isni.org/</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="17">
 				<xs:annotation>
 					<xs:documentation>PND</xs:documentation>
-					<xs:documentation>Personennamendatei – person name authority file used by Deutsche Nationalbibliothek and in other German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/pnd.htm (German) or http://www.d-nb.de/eng/standardisierung/normdateien/pnd.htm (English). DEPRECATED in favour of the GND</xs:documentation>
+					<xs:documentation>Personennamendatei – person name authority file used by Deutsche Nationalbibliothek and in other German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/pnd.htm (German) or http://www.d-nb.de/eng/standardisierung/normdateien/pnd.htm (English). DEPRECATED in favor of the GND</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="18">
@@ -6988,13 +3890,13 @@
 			<xs:enumeration value="20">
 				<xs:annotation>
 					<xs:documentation>GKD</xs:documentation>
-					<xs:documentation>Gemeinsame Körperschaftsdatei – Corporate Body Authority File in the German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/gkd.htm (German) or http://www.d-nb.de/eng/standardisierung/normdateien/gkd.htm (English). DEPRECATED in favour of the GND</xs:documentation>
+					<xs:documentation>Gemeinsame Körperschaftsdatei – Corporate Body Authority File in the German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/gkd.htm (German) or http://www.d-nb.de/eng/standardisierung/normdateien/gkd.htm (English). DEPRECATED in favor of the GND</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="21">
 				<xs:annotation>
 					<xs:documentation>ORCID</xs:documentation>
-					<xs:documentation>Open Researcher and Contributor ID. See http://www.orcid.org/</xs:documentation>
+					<xs:documentation>Open Researcher and Contributor ID. A sixteen digit number. Usually presented with hyphens dividing the number into four groups of four digits, but in ONIX the hyphens should be omitted. See http://www.orcid.org/</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="22">
@@ -7030,7 +3932,7 @@
 			<xs:enumeration value="27">
 				<xs:annotation>
 					<xs:documentation>Ringgold ID</xs:documentation>
-					<xs:documentation>Ringgold organizational identifier, see http://www.ringgold.com/pages/identify.html</xs:documentation>
+					<xs:documentation>Ringgold organizational identifier, see http://www.ringgold.com/identify.html</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="28">
@@ -7063,11 +3965,41 @@
 					<xs:documentation>DOI used in CrossRef’s Open Funder Registry list of academic research funding bodies, for example ‘10.13039/100004440’ (Wellcome Trust). See http://www.crossref.org/fundingdata/registry.html</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>BNE CN</xs:documentation>
+					<xs:documentation>Control number assigned to a Name Authority record by the Biblioteca Nacional de España</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>BNF Control Number</xs:documentation>
+					<xs:documentation>Numéro de la notice de personne BNF</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>ARK</xs:documentation>
+					<xs:documentation>Archival Resource Key, as a URL (including the address of the ARK resolver provided by eg a national library)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>Nasjonalt autoritetsregister</xs:documentation>
+					<xs:documentation>Nasjonalt autoritetsregister for navn – Norwegian national authority file for personal and corporate names. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>GRID</xs:documentation>
+					<xs:documentation>Global Research Identifier Database ID (see https://www.grid.ac). For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List45">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 45">Publishing role code</xs:documentation>
+			<xs:documentation source="ONIX Code List 45">Publishing role</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -7151,19 +4083,19 @@
 			<xs:enumeration value="14">
 				<xs:annotation>
 					<xs:documentation>Publication funder</xs:documentation>
-					<xs:documentation>Body funding publication fees, if different from the body funding the underlying research. For use with open access publications</xs:documentation>
+					<xs:documentation>Body funding publication fees, if different from the body funding the underlying research. Intended primarily for use with open access publications</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="15">
 				<xs:annotation>
 					<xs:documentation>Research funder</xs:documentation>
-					<xs:documentation>Body funding the research on which publication is based, if different from the body funding the publication. For use with open access publications</xs:documentation>
+					<xs:documentation>Body funding the research on which publication is based, if different from the body funding the publication. Intended primarily for use with open access publications</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="16">
 				<xs:annotation>
 					<xs:documentation>Funding body</xs:documentation>
-					<xs:documentation>Body funding research and publication. For use with open access publications</xs:documentation>
+					<xs:documentation>Body funding research and publication. Intended primarily for use with open access publications</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="17">
@@ -7188,7 +4120,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List46">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 46">Sales rights type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 46">Sales rights type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -7247,58 +4179,27 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="List47">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 47">Rights region</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="000">
-				<xs:annotation>
-					<xs:documentation>World</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="001">
-				<xs:annotation>
-					<xs:documentation>World except territories specified elsewhere in rights statements</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="002">
-				<xs:annotation>
-					<xs:documentation>UK airports</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="003">
-				<xs:annotation>
-					<xs:documentation>UK ‘open market’</xs:documentation>
-					<xs:documentation>Use when an open market edition is published under its own ISBN</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="List48">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 48">Measure type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 48">Measure type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Height</xs:documentation>
-					<xs:documentation>For a book, the spine height when standing on a shelf. For a folded map, the height when folded. In general, the height of a product in the form in which it is presented or packaged for retail sale</xs:documentation>
+					<xs:documentation>For a book, the overall height when standing on a shelf. For a folded map, the height when folded. For packaged products, the height of the retail packaging. In general, the height of a product in the form in which it is presented or packaged for retail sale</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>Width</xs:documentation>
-					<xs:documentation>For a book, the horizontal dimension of the cover when standing upright. For a folded map, the width when folded. In general, the width of a product in the form in which it is presented or packaged for retail sale</xs:documentation>
+					<xs:documentation>For a book, the overall horizontal dimension of the cover when standing upright. For a folded map, the width when folded. For packaged products, the width of the retail packaging. In general, the width of a product in the form in which it is presented or packaged for retail sale</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>Thickness</xs:documentation>
-					<xs:documentation>For a book, the thickness of the spine. For a folded map, the thickness when folded. In general, the thickness or depth of a product in the form in which it is presented or packaged for retail sale</xs:documentation>
+					<xs:documentation>For a book, the overall thickness of the spine. For a folded map, the thickness when folded. For packaged products, the depth of the packaging. In general, the thickness or depth of a product in the form in which it is presented or packaged for retail sale</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="04">
@@ -7316,7 +4217,7 @@
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Unit weight</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>The weight of the product, including any retail packaging</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
@@ -7349,11 +4250,41 @@
 					<xs:documentation>The length of a side of the cross-section of a long triangular or square package, usually carrying a rolled sheet product. Use 01 ‘Height’ for the height or length of the package</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Unpackaged height</xs:documentation>
+					<xs:documentation>As height, but of the product without packaging (use only for products supplied in retail packaging, must also supply overall size when packaged using code 01). For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Unpackaged width</xs:documentation>
+					<xs:documentation>As width, but of the product without packaging (use only for products supplied in retail packaging, must also supply overall size when packaged using code 02). For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Unpackaged thickness</xs:documentation>
+					<xs:documentation>As thickness, but of the product without packaging (use only for products supplied in retail packaging, must also supply overall size when packaged using code 03). For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Total battery weight</xs:documentation>
+					<xs:documentation>Weight of batteries built-in, pre-installed or supplied with the product. Details of the batteries should be provided using &lt;ProductFormFeature&gt;. A per-battery unit weight may be calculated from the number of batteries if required. Use only with ONIX 3.0</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Total weight of Lithium</xs:documentation>
+					<xs:documentation>Mass or equivalent mass of elemental Lithium within the batteries built-in, pre-installed or supplied with the product (eg a Lithium Iron phosphate battery with 160g of cathode material would have a total of around 7g of Lithium). Details of the batteries must be provided using ProductFormFeature. A per-battery unit mass of Lithium may be calculated from the number of batteries if required. Use only with ONIX 3.0</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List49">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 49">Region code</xs:documentation>
+			<xs:documentation source="ONIX Code List 49">Region – based on ISO 3166-2</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="AU-CT">
@@ -7402,6 +4333,24 @@
 				<xs:annotation>
 					<xs:documentation>Western Australia</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BE-BRU">
+				<xs:annotation>
+					<xs:documentation>Brussels-Capital Region</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BE-VLG">
+				<xs:annotation>
+					<xs:documentation>Flemish Region</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BE-WAL">
+				<xs:annotation>
+					<xs:documentation>Walloon Region</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CA-AB">
@@ -7482,213 +4431,423 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="CN-BJ">
+				<xs:annotation>
+					<xs:documentation>Beijing Municipality</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-TJ">
+				<xs:annotation>
+					<xs:documentation>Tianjin Municipality</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-HE">
+				<xs:annotation>
+					<xs:documentation>Hebei Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-SX">
+				<xs:annotation>
+					<xs:documentation>Shanxi Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-NM">
+				<xs:annotation>
+					<xs:documentation>Inner Mongolia Autonomous Region</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-LN">
+				<xs:annotation>
+					<xs:documentation>Liaoning Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-JL">
+				<xs:annotation>
+					<xs:documentation>Jilin Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-HL">
+				<xs:annotation>
+					<xs:documentation>Heilongjiang Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-SH">
+				<xs:annotation>
+					<xs:documentation>Shanghai Municipality</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-JS">
+				<xs:annotation>
+					<xs:documentation>Jiangsu Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-ZJ">
+				<xs:annotation>
+					<xs:documentation>Zhejiang Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-AH">
+				<xs:annotation>
+					<xs:documentation>Anhui Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-FJ">
+				<xs:annotation>
+					<xs:documentation>Fujian Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-JX">
+				<xs:annotation>
+					<xs:documentation>Jiangxi Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-SD">
+				<xs:annotation>
+					<xs:documentation>Shandong Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-HA">
+				<xs:annotation>
+					<xs:documentation>Henan Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-HB">
+				<xs:annotation>
+					<xs:documentation>Hubei Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-HN">
+				<xs:annotation>
+					<xs:documentation>Hunan Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-GD">
+				<xs:annotation>
+					<xs:documentation>Guangdong Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-GX">
+				<xs:annotation>
+					<xs:documentation>Guangxi Zhuang Autonomous Region</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-HI">
+				<xs:annotation>
+					<xs:documentation>Hainan Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-CQ">
+				<xs:annotation>
+					<xs:documentation>Chongqing Municipality</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-SC">
+				<xs:annotation>
+					<xs:documentation>Sichuan Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-GZ">
+				<xs:annotation>
+					<xs:documentation>Guizhou Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-YN">
+				<xs:annotation>
+					<xs:documentation>Yunnan Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-XZ">
+				<xs:annotation>
+					<xs:documentation>Tibet Autonomous Region</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-SN">
+				<xs:annotation>
+					<xs:documentation>Shaanxi Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-GS">
+				<xs:annotation>
+					<xs:documentation>Gansu Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-QH">
+				<xs:annotation>
+					<xs:documentation>Qinghai Province</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-NX">
+				<xs:annotation>
+					<xs:documentation>Ningxia Hui Autonomous Region</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-XJ">
+				<xs:annotation>
+					<xs:documentation>Xinjiang Uyghur Autonomous Region</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-TW">
+				<xs:annotation>
+					<xs:documentation>Taiwan Province</xs:documentation>
+					<xs:documentation>Prefer code TW (Taiwan, Province of China) from List 91. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-HK">
+				<xs:annotation>
+					<xs:documentation>Hong Kong Special Administrative Region</xs:documentation>
+					<xs:documentation>Prefer code HK (Hong Kong) from List 91. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN-MO">
+				<xs:annotation>
+					<xs:documentation>Macau Special Administrative Region</xs:documentation>
+					<xs:documentation>Prefer code MO (Macao) from List 91. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="CN-11">
 				<xs:annotation>
 					<xs:documentation>Beijing Municipality</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-BJ</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-12">
 				<xs:annotation>
 					<xs:documentation>Tianjin Municipality</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-TJ</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-13">
 				<xs:annotation>
 					<xs:documentation>Hebei Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-HE</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-14">
 				<xs:annotation>
 					<xs:documentation>Shanxi Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-SX</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-15">
 				<xs:annotation>
 					<xs:documentation>Inner Mongolia Autonomous Region</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-NM</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-21">
 				<xs:annotation>
 					<xs:documentation>Liaoning Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-LN</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-22">
 				<xs:annotation>
 					<xs:documentation>Jilin Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-JL</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-23">
 				<xs:annotation>
 					<xs:documentation>Heilongjiang Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-HL</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-31">
 				<xs:annotation>
 					<xs:documentation>Shanghai Municipality</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-SH</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-32">
 				<xs:annotation>
 					<xs:documentation>Jiangsu Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-JS</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-33">
 				<xs:annotation>
 					<xs:documentation>Zhejiang Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-ZJ</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-34">
 				<xs:annotation>
 					<xs:documentation>Anhui Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-AH</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-35">
 				<xs:annotation>
 					<xs:documentation>Fujian Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-FJ</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-36">
 				<xs:annotation>
 					<xs:documentation>Jiangxi Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-JX</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-37">
 				<xs:annotation>
 					<xs:documentation>Shandong Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-SD</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-41">
 				<xs:annotation>
 					<xs:documentation>Henan Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-HA</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-42">
 				<xs:annotation>
 					<xs:documentation>Hubei Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-HB</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-43">
 				<xs:annotation>
 					<xs:documentation>Hunan Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-HN</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-44">
 				<xs:annotation>
 					<xs:documentation>Guangdong Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-GD</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-45">
 				<xs:annotation>
 					<xs:documentation>Guangxi Zhuang Autonomous Region</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-GX</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-46">
 				<xs:annotation>
 					<xs:documentation>Hainan Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-HI</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-50">
 				<xs:annotation>
 					<xs:documentation>Chongqing Municipality</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-CQ</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-51">
 				<xs:annotation>
 					<xs:documentation>Sichuan Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-SC</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-52">
 				<xs:annotation>
 					<xs:documentation>Guizhou Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-GZ</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-53">
 				<xs:annotation>
 					<xs:documentation>Yunnan Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-YN</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-54">
 				<xs:annotation>
 					<xs:documentation>Tibet Autonomous Region</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-XZ</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-61">
 				<xs:annotation>
 					<xs:documentation>Shaanxi Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-SN</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-62">
 				<xs:annotation>
 					<xs:documentation>Gansu Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-GS</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-63">
 				<xs:annotation>
 					<xs:documentation>Qinghai Province</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-QH</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-64">
 				<xs:annotation>
 					<xs:documentation>Ningxia Hui Autonomous Region</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-NX</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-65">
 				<xs:annotation>
 					<xs:documentation>Xinjiang Uyghur Autonomous Region</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Deprecated in favor of CN-XJ</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-71">
 				<xs:annotation>
 					<xs:documentation>Taiwan Province</xs:documentation>
-					<xs:documentation>Prefer code TW (Taiwan, Province of China) from List 91</xs:documentation>
+					<xs:documentation>Deprecated in favor of CN-TW, but prefer code TW (Taiwan, Province of China) from List 91</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-91">
 				<xs:annotation>
 					<xs:documentation>Hong Kong Special Administrative Region</xs:documentation>
-					<xs:documentation>Prefer code HK (Hong Kong) from List 91</xs:documentation>
+					<xs:documentation>Deprecated in favor of CN-HK, but prefer code HK (Hong Kong) from List 91</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CN-92">
 				<xs:annotation>
 					<xs:documentation>Macau Special Administrative Region</xs:documentation>
-					<xs:documentation>Prefer code MO (Macao) from List 91</xs:documentation>
+					<xs:documentation>Deprecated in favor of CN-MO, but prefer code MO (Macao) from List 91</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="ES-CN">
 				<xs:annotation>
 					<xs:documentation>Canary Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FR-H">
+				<xs:annotation>
+					<xs:documentation>Corsica</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
@@ -7707,7 +4866,7 @@
 			<xs:enumeration value="GB-CHA">
 				<xs:annotation>
 					<xs:documentation>Channel Islands</xs:documentation>
-					<xs:documentation>DEPRECATED, replaced by country codes GG – Guernsey, and JE – Jersey</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by country codes GG – Guernsey, and JE – Jersey from List 91</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GB-ENG">
@@ -7719,13 +4878,13 @@
 			<xs:enumeration value="GB-EWS">
 				<xs:annotation>
 					<xs:documentation>England, Wales, Scotland</xs:documentation>
-					<xs:documentation>UK excluding Northern Ireland</xs:documentation>
+					<xs:documentation>UK excluding Northern Ireland. DEPRECATED – use separate region codes GB-ENG, GB-SCT, GB-WLS instead</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GB-IOM">
 				<xs:annotation>
 					<xs:documentation>Isle of Man</xs:documentation>
-					<xs:documentation>DEPRECATED, replaced by country code IM – Isle of Man</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by country code IM – Isle of Man from List 91</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GB-NIR">
@@ -9231,26 +6390,20 @@
 			<xs:enumeration value="ECZ">
 				<xs:annotation>
 					<xs:documentation>Eurozone</xs:documentation>
-					<xs:documentation>Countries geographically within continental Europe which use the Euro as their sole currency. At the time of writing, this is a synonym for ‘AT BE CY EE FI FR DE ES GR IE IT LT LU LV MT NL PT SI SK’ (the official Eurozone 19), plus ‘AD MC SM VA ME’ and Kosovo (other Euro-using countries in continental Europe). Note some other territories using the Euro, but outside continental Europe are excluded from this list, and may need to be specified separately. ONLY valid in ONIX 3, and ONLY within P.26. Use of an explicit list of countries instead of ECZ is strongly encouraged</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ROW">
-				<xs:annotation>
-					<xs:documentation>Rest of world</xs:documentation>
-					<xs:documentation>World except as otherwise specified. NOT USED in ONIX 3</xs:documentation>
+					<xs:documentation>Countries geographically within continental Europe which use the Euro as their sole currency. At the time of writing, this is a synonym for ‘AT BE CY EE FI FR DE ES GR IE IT LT LU LV MT NL PT SI SK’ (the official Eurozone 19), plus ‘AD MC SM VA ME’ and Kosovo (other Euro-using countries in continental Europe). Note some other territories using the Euro, but outside continental Europe are excluded from this list, and may need to be specified separately. ONLY valid in ONIX 3, and ONLY within P.26 – and this use is itself DEPRECATED. Use of an explicit list of countries instead of ECZ is strongly encouraged</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="WORLD">
 				<xs:annotation>
 					<xs:documentation>World</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>In ONIX 3, may ONLY be used in &lt;RegionsIncluded&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List50">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 50">Measure unit code</xs:documentation>
+			<xs:documentation source="ONIX Code List 50">Measure unit</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="cm">
@@ -9305,7 +6458,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List51">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 51">Product relation code</xs:documentation>
+			<xs:documentation source="ONIX Code List 51">Product relation</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -9317,61 +6470,61 @@
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Includes</xs:documentation>
-					<xs:documentation>&lt;Product&gt; includes &lt;RelatedProduct&gt;</xs:documentation>
+					<xs:documentation>&lt;Product&gt; includes &lt;RelatedProduct&gt; (inverse of code 02)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>Is part of</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is part of &lt;RelatedProduct&gt;: use for ‘also available as part of’</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is part of &lt;RelatedProduct&gt;: use for ‘also available as part of’ (inverse of code 01)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>Replaces</xs:documentation>
-					<xs:documentation>&lt;Product&gt; replaces, or is new edition of, &lt;RelatedProduct&gt;</xs:documentation>
+					<xs:documentation>&lt;Product&gt; replaces, or is new edition of, &lt;RelatedProduct&gt; (inverse of code 05)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
 				<xs:annotation>
 					<xs:documentation>Replaced by</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is replaced by, or has new edition, &lt;RelatedProduct&gt; (reciprocal of code 03)</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is replaced by, or has new edition, &lt;RelatedProduct&gt; (inverse of code 03)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
 				<xs:annotation>
 					<xs:documentation>Alternative format</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is available in an alternative format as &lt;RelatedProduct&gt; – indicates an alternative format of the same content which is or may be available</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is available in an alternative format as &lt;RelatedProduct&gt; – indicates an alternative format of the same content which is or may be available (is own inverse)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="07">
 				<xs:annotation>
 					<xs:documentation>Has ancillary product</xs:documentation>
-					<xs:documentation>&lt;Product&gt; has an ancillary or supplementary product &lt;RelatedProduct&gt;</xs:documentation>
+					<xs:documentation>&lt;Product&gt; has an ancillary or supplementary product &lt;RelatedProduct&gt; (inverse of code 08)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Is ancillary to</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is ancillary or supplementary to &lt;RelatedProduct&gt;</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is ancillary or supplementary to &lt;RelatedProduct&gt; (inverse of code 07)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
 				<xs:annotation>
 					<xs:documentation>Is remaindered as</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is remaindered as &lt;RelatedProduct&gt;, when a remainder merchant assigns its own identifier to the product</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is remaindered as &lt;RelatedProduct&gt;, when a remainder merchant assigns its own identifier to the product (inverse of code 10)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="10">
 				<xs:annotation>
 					<xs:documentation>Is remainder of</xs:documentation>
-					<xs:documentation>&lt;Product&gt; was originally sold as &lt;RelatedProduct&gt;, indicating the publisher’s original identifier for a title which is offered as a remainder under a different identifier (reciprocal of code 09)</xs:documentation>
+					<xs:documentation>&lt;Product&gt; was originally sold as &lt;RelatedProduct&gt;, indicating the publisher’s original identifier for a title which is offered as a remainder under a different identifier (inverse of code 09)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="11">
 				<xs:annotation>
 					<xs:documentation>Is other-language version of</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is an other-language version of &lt;RelatedProduct&gt;</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is an other-language version of &lt;RelatedProduct&gt; (is own inverse)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="12">
@@ -9383,55 +6536,43 @@
 			<xs:enumeration value="13">
 				<xs:annotation>
 					<xs:documentation>Epublication based on (print product)</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is an epublication based on printed product &lt;RelatedProduct&gt;</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="14">
-				<xs:annotation>
-					<xs:documentation>Epublication is distributed as</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is an epublication ‘rendered’ as &lt;RelatedProduct&gt;: use in ONIX 2.1 only when the &lt;Product&gt; record describes a package of electronic content which is available in multiple ‘renderings’ (coded 000 in &lt;EpubTypeCode&gt;): NOT USED in ONIX 3.0</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="15">
-				<xs:annotation>
-					<xs:documentation>Epublication is a rendering of</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is a ‘rendering’ of an epublication &lt;RelatedProduct&gt;: use in ONIX 2.1 only when the &lt;Product&gt; record describes a specific rendering of an epublication content package, to identify the package: NOT USED in ONIX 3.0</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is an epublication based on printed product &lt;RelatedProduct&gt;. The related product is the source of any print-equivalent page numbering present in the epublication</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="16">
 				<xs:annotation>
 					<xs:documentation>POD replacement for</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is a POD replacement for &lt;RelatedProduct&gt;. &lt;RelatedProduct&gt; is an out-of-print product replaced by a print-on-demand version under a new ISBN</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is a POD replacement for &lt;RelatedProduct&gt;. &lt;RelatedProduct&gt; is an out-of-print product replaced by a print-on-demand version under a new ISBN (inverse of code 17)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="17">
 				<xs:annotation>
 					<xs:documentation>Replaced by POD</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is replaced by POD &lt;RelatedProduct&gt;. &lt;RelatedProduct&gt; is a print-on-demand replacement, under a new ISBN, for an out-of-print &lt;Product&gt; (reciprocal of code 16)</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is replaced by POD &lt;RelatedProduct&gt;. &lt;RelatedProduct&gt; is a print-on-demand replacement, under a new ISBN, for an out-of-print &lt;Product&gt; (inverse of code 16)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="18">
 				<xs:annotation>
 					<xs:documentation>Is special edition of</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is a special edition of &lt;RelatedProduct&gt;. Used for a special edition (German: Sonderausgabe) with different cover, binding, premium content etc – more than ‘alternative format’ – which may be available in limited quantity and for a limited time</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is a special edition of &lt;RelatedProduct&gt;. Used for a special edition (German: Sonderausgabe) with different cover, binding, premium content etc – more than ‘alternative format’ – which may be available in limited quantity and for a limited time (inverse of code 19)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="19">
 				<xs:annotation>
 					<xs:documentation>Has special edition</xs:documentation>
-					<xs:documentation>&lt;Product&gt; has a special edition &lt;RelatedProduct&gt; (reciprocal of code 18)</xs:documentation>
+					<xs:documentation>&lt;Product&gt; has a special edition &lt;RelatedProduct&gt; (inverse of code 18)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="20">
 				<xs:annotation>
 					<xs:documentation>Is prebound edition of</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is a prebound edition of &lt;RelatedProduct&gt; (in the US, a prebound edition is ‘a book that was previously bound and has been rebound with a library quality hardcover binding. In almost all commercial cases, the book in question began as a paperback.’)</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is a prebound edition of &lt;RelatedProduct&gt; (In the US, a ‘prebound’ edition is ‘a book that was previously bound and has been rebound with a library quality hardcover binding. In almost all commercial cases, the book in question began as a paperback. This might also be termed ‘re-bound’) (inverse of code 21)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="21">
 				<xs:annotation>
 					<xs:documentation>Is original of prebound edition</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is the regular edition of which &lt;RelatedProduct&gt; is a prebound edition</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is the regular edition of which &lt;RelatedProduct&gt; is a prebound edition (inverse of code 20)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="22">
@@ -9443,19 +6584,19 @@
 			<xs:enumeration value="23">
 				<xs:annotation>
 					<xs:documentation>Similar product</xs:documentation>
-					<xs:documentation>&lt;RelatedProduct&gt; is another product that is suggested as similar to &lt;Product&gt; (‘if you liked &lt;Product&gt;, you may also like &lt;RelatedProduct&gt;’)</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct&gt; is another product that is suggested as similar to &lt;Product&gt; (‘if you liked &lt;Product&gt;, you may also like &lt;RelatedProduct&gt;’, or vice versa)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="24">
 				<xs:annotation>
 					<xs:documentation>Is facsimile of</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is a facsimile edition of &lt;RelatedProduct&gt;</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is a facsimile edition of &lt;RelatedProduct&gt; (inverse of code 25)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="25">
 				<xs:annotation>
 					<xs:documentation>Is original of facsimile</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is the original edition from which a facsimile edition &lt;RelatedProduct&gt; is taken (reciprocal of code 25)</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is the original edition from which a facsimile edition &lt;RelatedProduct&gt; is taken (inverse of code 24)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="26">
@@ -9467,86 +6608,103 @@
 			<xs:enumeration value="27">
 				<xs:annotation>
 					<xs:documentation>Electronic version available as</xs:documentation>
-					<xs:documentation>&lt;RelatedProduct&gt; is an electronic version of print &lt;Product&gt; (reciprocal of code 13)</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct&gt; is an electronic version of print &lt;Product&gt; (inverse of code 13)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="28">
 				<xs:annotation>
 					<xs:documentation>Enhanced version available as</xs:documentation>
-					<xs:documentation>&lt;RelatedProduct&gt; is an ‘enhanced’ version of &lt;Product&gt;, with additional content. Typically used to link an enhanced e-book to its original ‘unenhanced’ equivalent, but not specifically limited to linking e-books – for example, may be used to link illustrated and non-illustrated print books. &lt;Product&gt; and &lt;RelatedProduct&gt; should share the same &lt;ProductForm&gt;</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct&gt; is an ‘enhanced’ version of &lt;Product&gt;, with additional content. Typically used to link an enhanced e-book to its original ‘unenhanced’ equivalent, but not specifically limited to linking e-books – for example, may be used to link illustrated and non-illustrated print books. &lt;Product&gt; and &lt;RelatedProduct&gt; should share the same &lt;ProductForm&gt; (inverse of code 29)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="29">
 				<xs:annotation>
 					<xs:documentation>Basic version available as</xs:documentation>
-					<xs:documentation>&lt;RelatedProduct&gt; is a basic version of &lt;Product&gt; (reciprocal of code 28). &lt;Product&gt; and &lt;RelatedProduct&gt; should share the same &lt;ProductForm&gt;</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct&gt; is a basic version of &lt;Product&gt;. &lt;Product&gt; and &lt;RelatedProduct&gt; should share the same &lt;ProductForm&gt; (inverse of code 28)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="30">
 				<xs:annotation>
 					<xs:documentation>Product in same collection</xs:documentation>
-					<xs:documentation>&lt;RelatedProduct&gt; and &lt;Product&gt; are part of the same collection (eg two products in same series or set)</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct&gt; and &lt;Product&gt; are part of the same collection (eg two products in same series or set) (is own inverse)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="31">
 				<xs:annotation>
 					<xs:documentation>Has alternative in a different market sector</xs:documentation>
-					<xs:documentation>&lt;RelatedProduct&gt; is an alternative product in another sector (of the same geographical market). Indicates an alternative that carries the same content, but available to a different set of customers, as one or both products are retailer-, channel- or market sector-specific</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct&gt; is an alternative product in another sector (of the same geographical market). Indicates an alternative that carries the same content, but available to a different set of customers, as one or both products are retailer-, channel- or market sector-specific (is own inverse)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="32">
 				<xs:annotation>
 					<xs:documentation>Has equivalent intended for a different market</xs:documentation>
-					<xs:documentation>&lt;RelatedProduct&gt; is an equivalent product, often intended for another (geographical) market. Indicates an alternative that carries essentially the same content, though slightly adapted for local circumstances (as opposed to a translation – use code 11)</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct&gt; is an equivalent product, often intended for another (geographical) market. Indicates an alternative that carries essentially the same content, though slightly adapted for local circumstances (as opposed to a translation – use code 11) (is own inverse)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="33">
 				<xs:annotation>
 					<xs:documentation>Has alternative intended for different market</xs:documentation>
-					<xs:documentation>&lt;RelatedProduct&gt; is an alternative product, often intended for another (geographical) market. Indicates the content of the alternative is identical in all respects</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct&gt; is an alternative product, often intended for another (geographical) market. Indicates the content of the alternative is identical in all respects (is own inverse)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="34">
 				<xs:annotation>
 					<xs:documentation>Cites</xs:documentation>
-					<xs:documentation>&lt;Product&gt; cites &lt;RelatedProduct&gt;</xs:documentation>
+					<xs:documentation>&lt;Product&gt; cites &lt;RelatedProduct&gt; (inverse of code 35)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="35">
 				<xs:annotation>
 					<xs:documentation>Is cited by</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is the object of a citation in &lt;RelatedProduct&gt;</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="36">
-				<xs:annotation>
-					<xs:documentation>Sales expectation</xs:documentation>
-					<xs:documentation>Use to give the ISBN of another book that had sales (both in terms of copy numbers and customer profile) comparable to that the publisher or distributor estimates for the product. Use in ONIX 2.1 ONLY</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is the object of a citation in &lt;RelatedProduct&gt; (inverse of code 34)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="37">
 				<xs:annotation>
 					<xs:documentation>Is signed version of</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is a signed copy of &lt;RelatedProduct&gt;. Use where signed copies are given a distinct product identifier and can be ordered separately, but are otherwise identical</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is a signed copy of &lt;RelatedProduct&gt;. Use where signed copies are given a distinct product identifier and can be ordered separately, but are otherwise identical (inverse of code 38)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="38">
 				<xs:annotation>
 					<xs:documentation>Has signed version</xs:documentation>
-					<xs:documentation>&lt;Product&gt; is an unsigned copy of &lt;RelatedProduct&gt;. Use where signed copies are given a distinct product identifier and can be ordered separately, but are otherwise identical</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is an unsigned copy of &lt;RelatedProduct&gt;. Use where signed copies are given a distinct product identifier and can be ordered separately, but are otherwise identical (inverse of code 37)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List52">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 52">Supply-to region code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="004">
+			<xs:enumeration value="39">
 				<xs:annotation>
-					<xs:documentation>UK ‘open market’</xs:documentation>
-					<xs:documentation>When the same ISBN is used for open market and UK editions</xs:documentation>
+					<xs:documentation>Has related student material</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is intended for teacher use, and the related product is for student use</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Has related teacher material</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is intended for student use, and the related product is for teacher use</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Some content shared with</xs:documentation>
+					<xs:documentation>&lt;Product&gt; includes some content shared with &lt;RelatedProduct&gt;. Note the shared content does not form the whole of either product. Compare with the ‘includes’ / ‘is part of’ relationship pair (codes 01 and 02), where the shared content forms the whole of one of the products, and with the ‘alternative format’ relationship (code 06), where the shared content forms the whole of both products (code 41 is own inverse)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Is later edition of first edition</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is a later edition of &lt;RelatedProduct&gt;, where the related product is the first edition</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Adapted from</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is an adapted (dramatized, abridged, novelized etc) version of &lt;RelatedProduct&gt; (inverse of code 44). For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Adapted as</xs:documentation>
+					<xs:documentation>&lt;Product&gt; is the original from which &lt;RelatedProduct&gt; is adapted (dramatized etc) (inverse of code 43), For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -9559,7 +6717,7 @@
 			<xs:enumeration value="00">
 				<xs:annotation>
 					<xs:documentation>Proprietary</xs:documentation>
-					<xs:documentation>As specified in &lt;ReturnsCodeTypeName&gt;</xs:documentation>
+					<xs:documentation>As specified in &lt;ReturnsCodeTypeName&gt; (ONIX 3.0 only)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="01">
@@ -9588,151 +6746,6 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="List54">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 54">Availability status code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="AB">
-				<xs:annotation>
-					<xs:documentation>Cancelled</xs:documentation>
-					<xs:documentation>Publication abandoned after having been announced</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="AD">
-				<xs:annotation>
-					<xs:documentation>Available direct from publisher only</xs:documentation>
-					<xs:documentation>Apply direct to publisher, item not available to trade</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="CS">
-				<xs:annotation>
-					<xs:documentation>Availability uncertain</xs:documentation>
-					<xs:documentation>Check with customer service</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="EX">
-				<xs:annotation>
-					<xs:documentation>No longer stocked by us</xs:documentation>
-					<xs:documentation>Wholesaler or vendor only</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="IP">
-				<xs:annotation>
-					<xs:documentation>Available</xs:documentation>
-					<xs:documentation>In-print and in stock</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="MD">
-				<xs:annotation>
-					<xs:documentation>Manufactured on demand</xs:documentation>
-					<xs:documentation>May be accompanied by an estimated average time to supply</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="NP">
-				<xs:annotation>
-					<xs:documentation>Not yet published</xs:documentation>
-					<xs:documentation>MUST be accompanied by an expected availability date</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="NY">
-				<xs:annotation>
-					<xs:documentation>Newly catalogued, not yet in stock</xs:documentation>
-					<xs:documentation>Wholesaler or vendor only: MUST be accompanied by expected availability date</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="OF">
-				<xs:annotation>
-					<xs:documentation>Other format available</xs:documentation>
-					<xs:documentation>This format is out of print, but another format is available: should be accompanied by an identifier for the alternative product</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="OI">
-				<xs:annotation>
-					<xs:documentation>Out of stock indefinitely</xs:documentation>
-					<xs:documentation>No current plan to reprint</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="OP">
-				<xs:annotation>
-					<xs:documentation>Out of print</xs:documentation>
-					<xs:documentation>Discontinued, deleted from catalogue</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="OR">
-				<xs:annotation>
-					<xs:documentation>Replaced by new edition</xs:documentation>
-					<xs:documentation>This edition is out of print, but a new edition has been or will soon be published: should be accompanied by an identifier for the new edition</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="PP">
-				<xs:annotation>
-					<xs:documentation>Publication postponed indefinitely</xs:documentation>
-					<xs:documentation>Publication has been announced, and subsequently postponed with no new date</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="RF">
-				<xs:annotation>
-					<xs:documentation>Refer to another supplier</xs:documentation>
-					<xs:documentation>Supply of this item has been transferred to another publisher or distributor: should be accompanied by an identifier for the new supplier</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="RM">
-				<xs:annotation>
-					<xs:documentation>Remaindered</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="RP">
-				<xs:annotation>
-					<xs:documentation>Reprinting</xs:documentation>
-					<xs:documentation>MUST be accompanied by an expected availability date</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="RU">
-				<xs:annotation>
-					<xs:documentation>Reprinting, undated</xs:documentation>
-					<xs:documentation>Use instead of RP as a last resort, only if it is really impossible to give an expected availability date</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="TO">
-				<xs:annotation>
-					<xs:documentation>Special order</xs:documentation>
-					<xs:documentation>This item is not stocked but has to be specially ordered from a supplier (eg import item not stocked locally): may be accompanied by an estimated average time to supply</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="TP">
-				<xs:annotation>
-					<xs:documentation>Temporarily out of stock because publisher cannot supply</xs:documentation>
-					<xs:documentation>Wholesaler or vendor only</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="TU">
-				<xs:annotation>
-					<xs:documentation>Temporarily unavailable</xs:documentation>
-					<xs:documentation>MUST be accompanied by an expected availability date</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="UR">
-				<xs:annotation>
-					<xs:documentation>Unavailable, awaiting reissue</xs:documentation>
-					<xs:documentation>The item is out of stock but will be reissued under the same ISBN: MUST be accompanied by an expected availability date and by the reissue date in the &lt;Reissue&gt; composite. See notes on the &lt;Reissue&gt; composite for details on treatment of availability status during reissue</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="WR">
-				<xs:annotation>
-					<xs:documentation>Will be remaindered as of (date)</xs:documentation>
-					<xs:documentation>MUST be accompanied by the remainder date</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="WS">
-				<xs:annotation>
-					<xs:documentation>Withdrawn from sale</xs:documentation>
-					<xs:documentation>Typically, withdrawn indefinitely for legal reasons</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="List55">
 		<xs:annotation>
 			<xs:documentation source="ONIX Code List 55">Date format</xs:documentation>
@@ -9741,7 +6754,7 @@
 			<xs:enumeration value="00">
 				<xs:annotation>
 					<xs:documentation>YYYYMMDD</xs:documentation>
-					<xs:documentation>Year month day (default)</xs:documentation>
+					<xs:documentation>Common Era year, month and day (default for most dates)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="01">
@@ -9771,7 +6784,7 @@
 			<xs:enumeration value="05">
 				<xs:annotation>
 					<xs:documentation>YYYY</xs:documentation>
-					<xs:documentation>Year</xs:documentation>
+					<xs:documentation>Year (default for some dates)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
@@ -9813,7 +6826,7 @@
 			<xs:enumeration value="12">
 				<xs:annotation>
 					<xs:documentation>Text string</xs:documentation>
-					<xs:documentation>For complex, approximate or uncertain dates</xs:documentation>
+					<xs:documentation>For complex, approximate or uncertain dates, or dates BCE</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="13">
@@ -9854,28 +6867,9 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="List56">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 56">Audience restriction flag</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="R">
-				<xs:annotation>
-					<xs:documentation>Restrictions apply, see note</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="X">
-				<xs:annotation>
-					<xs:documentation>Indiziert</xs:documentation>
-					<xs:documentation>Indexed for the German market – in Deutschland indiziert</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="List57">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 57">Unpriced item type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 57">Unpriced item type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -9918,61 +6912,61 @@
 	</xs:simpleType>
 	<xs:simpleType name="List58">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 58">Price type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 58">Price type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>RRP excluding tax</xs:documentation>
-					<xs:documentation>RRP excluding any sales tax or value-added tax</xs:documentation>
+					<xs:documentation>Recommended Retail Price, excluding any sales tax or value-added tax. Price recommended by the publisher or supplier for retail sales to the consumer. Also termed the Suggested Retail Price (SRP) or Maximum Suggested Retail Price (MSRP) in some countries. The retailer may choose to use this recommended price, or may choose to sell to the consumer at a lower (or occasionally, a higher) price which is termed the Actual Selling Price (ASP) in sales reports. The net price charged to the retailer depends on the RRP minus a trade discount (which may be customer-specific). Relevant tax detail must be calculated by the data recipient</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>RRP including tax</xs:documentation>
-					<xs:documentation>RRP including sales or value-added tax if applicable</xs:documentation>
+					<xs:documentation>Recommended Retail Price, including sales or value-added tax where applicable. The net price charged to the retailer depends on the trade discount. Sales or value-added tax detail is usually supplied in the &lt;Tax&gt; composite</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
 				<xs:annotation>
-					<xs:documentation>Fixed retail price excluding tax</xs:documentation>
-					<xs:documentation>In countries where retail price maintenance applies by law to certain products: not used in USA</xs:documentation>
+					<xs:documentation>FRP excluding tax</xs:documentation>
+					<xs:documentation>Fixed Retail Price, excluding any sales or value-added tax, used in countries were retail price maintenance applies by law to certain products. Price fixed by the publisher or supplier for retail sales to the consumer. The retailer must use this price, or may vary the price only within certain legally-prescribed limits. The net price charged to the retailer depends on the FRP minus a customer-soecific trade discount. Relevant tax detail must be calculated by the data recipient</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="04">
 				<xs:annotation>
-					<xs:documentation>Fixed retail price including tax</xs:documentation>
-					<xs:documentation>In countries where retail price maintenance applies by law to certain products: not used in USA</xs:documentation>
+					<xs:documentation>FRP including tax</xs:documentation>
+					<xs:documentation>Fixed Retail Price, including any sales or value-added tax where applicable, used in countries were retail price maintenance applies by law to certain products. The net price charged to the retailer depends on the trade discount. Sales or value-added tax detail is usually supplied in the &lt;Tax&gt; composite</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
 				<xs:annotation>
-					<xs:documentation>Supplier’s net price excluding tax</xs:documentation>
-					<xs:documentation>Unit price charged by supplier to reseller excluding any sales tax or value-added tax: goods for retail sale</xs:documentation>
+					<xs:documentation>Supplier’s Net price excluding tax</xs:documentation>
+					<xs:documentation>Net or wholesale price, excluding any sales or value-added tax. Unit price charged by supplier for business-to-business transactions, without any direct relationship to the price for retail sales to the consumer, but sometimes subject to a further customer-specific trade discount based on volume. Relevant tax detail must be calculated by the data recipient</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
 				<xs:annotation>
-					<xs:documentation>Supplier’s net price excluding tax: rental goods</xs:documentation>
+					<xs:documentation>Supplier’s Net price excluding tax: rental goods</xs:documentation>
 					<xs:documentation>Unit price charged by supplier to reseller / rental outlet, excluding any sales tax or value-added tax: goods for rental (used for video and DVD)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="07">
 				<xs:annotation>
-					<xs:documentation>Supplier’s net price including tax</xs:documentation>
-					<xs:documentation>Unit price charged by supplier to reseller including any sales tax or value-added tax if applicable: goods for retail sale</xs:documentation>
+					<xs:documentation>Supplier’s Net price including tax</xs:documentation>
+					<xs:documentation>Net or wholesale price, including any sales or value-added tax where applicable. Unit price charged by supplier for business-to-business transactions, without any direct relationship to the price for retail sales to the consumer, but sometimes subject to a further customer-specific trade discount based on volume. Sales or value-added tax detail is usually supplied in the &lt;Tax&gt; composite</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="08">
 				<xs:annotation>
-					<xs:documentation>Supplier’s alternative net price excluding tax</xs:documentation>
-					<xs:documentation>Unit price charged by supplier to a specified class of reseller excluding any sales tax or value-added tax: goods for retail sale (this value is for use only in countries, eg Finland, where trade practice requires two different net prices to be listed for different classes of resellers, and where national guidelines specify how the code should be used)</xs:documentation>
+					<xs:documentation>Supplier’s alternative Net price excluding tax</xs:documentation>
+					<xs:documentation>Net or wholesale price charged by supplier to a specified class of reseller, excluding any sales tax or value-added tax. Relevant tax detail must be calculated by the data recipient. (This value is for use only in countries, eg Finland, where trade practice requires two different Net prices to be listed for different classes of resellers, and where national guidelines specify how the code should be used)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
 				<xs:annotation>
 					<xs:documentation>Supplier’s alternative net price including tax</xs:documentation>
-					<xs:documentation>Unit price charged by supplier to a specified class of reseller including any sales tax or value-added tax: goods for retail sale (this value is for use only in countries, eg Finland, where trade practice requires two different net prices to be listed for different classes of resellers, and where national guidelines specify how the code should be used)</xs:documentation>
+					<xs:documentation>Net or wholesale price charged by supplier to a specified class of reseller, including any sales tax or value-added tax. Sales or value-added tax detail is usually supplied in the &lt;Tax&gt; composite. (This value is for use only in countries, eg Finland, where trade practice requires two different Net prices to be listed for different classes of resellers, and where national guidelines specify how the code should be used)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="11">
@@ -10196,7 +7190,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List60">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 60">Unit of pricing code</xs:documentation>
+			<xs:documentation source="ONIX Code List 60">Unit of pricing</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -10215,7 +7209,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List61">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 61">Price status code</xs:documentation>
+			<xs:documentation source="ONIX Code List 61">Price status</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -10240,7 +7234,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List62">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 62">Tax rate, coded</xs:documentation>
+			<xs:documentation source="ONIX Code List 62">Tax rate type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="H">
@@ -10258,13 +7252,19 @@
 			<xs:enumeration value="R">
 				<xs:annotation>
 					<xs:documentation>Lower rate</xs:documentation>
-					<xs:documentation>Specifies that tax is applied at a lower rate than standard</xs:documentation>
+					<xs:documentation>Specifies that tax is applied at a lower rate than standard. In the EU, use code R for ‘Reduced rates’, and for rates lower than 5%, use code T (‘Super-reduced’) or Z (Zero-rated)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="S">
 				<xs:annotation>
 					<xs:documentation>Standard rate</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="T">
+				<xs:annotation>
+					<xs:documentation>Super-low rate</xs:documentation>
+					<xs:documentation>Specifies that tax is applied at a rate lower than the Lower rate(s). In the EU, use code T for ‘Super-reduced rates’, and for Reduced rates (5% or above) use code R (Lower rate). For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Z">
@@ -10274,12 +7274,6 @@
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List63">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 63">Intermediary supplier availability</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
 	<xs:simpleType name="List64">
 		<xs:annotation>
@@ -10295,19 +7289,19 @@
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Cancelled</xs:documentation>
-					<xs:documentation>The product was announced, and subsequently abandoned; the &lt;PublicationDate&gt; element must not be sent</xs:documentation>
+					<xs:documentation>The product was announced, and subsequently abandoned; the &lt;PublicationDate&gt; element in ONIX 2.1 or its equivalent in &lt;PublishingDate&gt; in ONIX 3.0 must not be sent</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>Forthcoming</xs:documentation>
-					<xs:documentation>Not yet published, must be accompanied by expected date in &lt;PublicationDate&gt;</xs:documentation>
+					<xs:documentation>Not yet published; must be accompanied by the expected date in &lt;PublicationDate&gt; in ONIX 2.1, or its equivalent in the &lt;PublishingDate&gt; composite in ONIX 3.0</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>Postponed indefinitely</xs:documentation>
-					<xs:documentation>The product was announced, and subsequently postponed with no expected publication date; the &lt;Publication Date&gt; element (ONIX 2.1), or its equivalent as a date composite in ONIX 3.0, must not be sent</xs:documentation>
+					<xs:documentation>The product was announced, and subsequently postponed with no expected publication date; the &lt;PublicationDate&gt; element in ONIX 2.1, or its equivalent as a &lt;PublishingDate&gt; composite in ONIX 3.0, must not be sent</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="04">
@@ -10364,6 +7358,12 @@
 					<xs:documentation>Recalled for reasons of consumer safety. Deprecated, use code 15 instead</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Active, but not sold separately</xs:documentation>
+					<xs:documentation>The product is published and active but, as a publishing decision, it is not sold separately – only in an assembly or as part of a pack. Depending on product composition and pricing, it may be saleable separately at retail</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="15">
 				<xs:annotation>
 					<xs:documentation>Recalled</xs:documentation>
@@ -10379,7 +7379,7 @@
 			<xs:enumeration value="17">
 				<xs:annotation>
 					<xs:documentation>Permanently withdrawn from sale</xs:documentation>
-					<xs:documentation>Withdrawn permanently from the market. Effectively synonymous with ‘Out of print’ (code 07), but specific to downloadable and online digital products (where no ‘stock’ would remain in the supply chain)</xs:documentation>
+					<xs:documentation>Withdrawn permanently from sale in all markets. Effectively synonymous with ‘Out of print’ (code 07), but specific to downloadable and online digital products (where no ‘stock’ would remain in the supply chain)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -10393,6 +7393,12 @@
 				<xs:annotation>
 					<xs:documentation>Cancelled</xs:documentation>
 					<xs:documentation>Cancelled: product was announced, and subsequently abandoned</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Not yet available, postponed indefinitely</xs:documentation>
+					<xs:documentation>Not yet available, publisher indicates that it has been postponed indefinitely. Should be used in preference to code 10 where the publisher has indicated that a previously-announced publication date is no longer correct, and no new date has yet been announced. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="10">
@@ -10500,7 +7506,7 @@
 			<xs:enumeration value="45">
 				<xs:annotation>
 					<xs:documentation>Not sold separately</xs:documentation>
-					<xs:documentation>Must be bought as part of a set (identify set in &lt;RelatedProduct&gt;)</xs:documentation>
+					<xs:documentation>Must be bought as part of a set or trade pack (identify set or pack in &lt;RelatedProduct&gt;)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="46">
@@ -10596,25 +7602,6 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="List67">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 67">Market date role</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>Publication date</xs:documentation>
-					<xs:documentation>The nominal date of publication in this market. If there is a strict embargo on retail sales before the expected date, it should be specified separately as an embargo date</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>Embargo date</xs:documentation>
-					<xs:documentation>If there is an embargo on retail sales in this market before a certain date, the date from which the embargo is lifted and retail sales are permitted</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="List68">
 		<xs:annotation>
 			<xs:documentation source="ONIX Code List 68">Market publishing status</xs:documentation>
@@ -10629,19 +7616,19 @@
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Cancelled</xs:documentation>
-					<xs:documentation>The product was announced for publication in this market, and subsequently abandoned</xs:documentation>
+					<xs:documentation>The product was announced for publication in this market, and subsequently abandoned. A market publication date must not be sent</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>Forthcoming</xs:documentation>
-					<xs:documentation>Not yet published in this market, should be accompanied by expected local publication date.</xs:documentation>
+					<xs:documentation>Not yet published in this market, should be accompanied by expected local publication date</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>Postponed indefinitely</xs:documentation>
-					<xs:documentation>The product was announced for publication in this market, and subsequently postponed with no expected local publication date</xs:documentation>
+					<xs:documentation>The product was announced for publication in this market, and subsequently postponed with no expected local publication date. A market publication date must not be sent</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="04">
@@ -10653,25 +7640,25 @@
 			<xs:enumeration value="05">
 				<xs:annotation>
 					<xs:documentation>No longer our product</xs:documentation>
-					<xs:documentation>Responsibility for the product in this market has been transferred elsewhere</xs:documentation>
+					<xs:documentation>Responsibility for the product in this market has been transferred elsewhere (with details of acquiring publisher representative in this market if possible in PR.25 (ONIX 2.1) OR P.25 (ONIX 3.0))</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
 				<xs:annotation>
 					<xs:documentation>Out of stock indefinitely</xs:documentation>
-					<xs:documentation>The product was active, but is now inactive in the sense that (a) no further stock is expected to be made available in this market, though stock may still be available elsewhere in the supply chain, and (b) there are no current plans to bring it back into stock</xs:documentation>
+					<xs:documentation>The product was active in this market, but is now inactive in the sense that (a) the publisher representative (local publisher or sales agent) cannot fulfill orders for it, though stock may still be available elsewhere in the supply chain, and (b) there are no current plans to bring it back into stock in this market. Code 06 does not specifically imply that returns are or are not still accepted</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="07">
 				<xs:annotation>
 					<xs:documentation>Out of print</xs:documentation>
-					<xs:documentation>The product was active, but is now permanently inactive in the sense that (a) no further stock is expected to be made available in this market, though stock may still be available elsewhere in the supply chain, and (b) the product will not be made available again under the same ISBN</xs:documentation>
+					<xs:documentation>The product was active in this market, but is now permanently inactive in this market in the sense that (a) the publisher representative (local publisher or sales agent) will not accept orders for it, though stock may still be available elsewhere in the supply chain, and (b) the product will not be made available again in this market under the same ISBN. Code 07 normally implies that the publisher will not accept returns beyond a specified date</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Inactive</xs:documentation>
-					<xs:documentation>The product was active, but is now permanently or indefinitely inactive in the sense that no further stock is expected to be made available in this market, though stock may still be available elsewhere in the supply chain. Code 08 covers both of codes 06 and 07, and may be used where the distinction between those values is either unnecessary or meaningless</xs:documentation>
+					<xs:documentation>The product was active in this market, but is now permanently or indefinitely inactive in the sense that the publisher representative (local publisher or sales agent) will not accept orders for it, though stock may still be available elsewhere in the supply chain. Code 08 covers both of codes 06 and 07, and may be used where the distinction between those values is either unnecessary or meaningless</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
@@ -10683,13 +7670,13 @@
 			<xs:enumeration value="10">
 				<xs:annotation>
 					<xs:documentation>Remaindered</xs:documentation>
-					<xs:documentation>The product is no longer available in this market from the local publisher, under the current ISBN, at the current price. It may be available to be traded through another channel, usually at a reduced price</xs:documentation>
+					<xs:documentation>The product is no longer available in this market from the publisher representative (local publisher or sales agent), under the current ISBN, at the current price. It may be available to be traded through another channel, usually at a reduced price</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="11">
 				<xs:annotation>
 					<xs:documentation>Withdrawn from sale</xs:documentation>
-					<xs:documentation>Withdrawn from sale in this market, typically for legal reasons</xs:documentation>
+					<xs:documentation>Withdrawn from sale in this market, typically for legal reasons or to avoid giving offence</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="12">
@@ -10701,7 +7688,7 @@
 			<xs:enumeration value="13">
 				<xs:annotation>
 					<xs:documentation>Active, but not sold separately</xs:documentation>
-					<xs:documentation>The product is published in this market and active but, as a publishing decision, it is not sold separately – only in an assembly or as part of a package</xs:documentation>
+					<xs:documentation>The product is published in this market and active but, as a publishing decision, it is not sold separately – only in an assembly or as part of a package. Depending on product composition and pricing, it may be saleable separately at retail</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="14">
@@ -10776,7 +7763,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List71">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 71">Sales restriction type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 71">Sales restriction type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -10863,11 +7850,23 @@
 					<xs:documentation>Restricted to organisations or services offering consumers subscription access to a library of books</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Not for retail online</xs:documentation>
+					<xs:documentation>Exclusive to bricks-and-mortar retail outlets</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Online retail only</xs:documentation>
+					<xs:documentation>Exclusive to online retail outlets</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List72">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 72">Thesis type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 72">Thesis type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -11072,7 +8071,7 @@
 			<xs:enumeration value="29">
 				<xs:annotation>
 					<xs:documentation>Web page for full content</xs:documentation>
-					<xs:documentation>Use this value in the &lt;Website&gt; composite in &lt;SupplyDetail&gt; when sending a link to a webpage at which a digital product is available for download and/or online access</xs:documentation>
+					<xs:documentation>Use this value in the &lt;Website&gt; composite (typically within &lt;Publisher&gt; or &lt;SupplyDetail&gt;) when sending a link to a webpage at which a digital product is available for download and/or online access</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="30">
@@ -11171,11 +8170,17 @@
 					<xs:documentation>For example, a service offering click-through licensing of extracts</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Publisher’s or third party website for privacy statement</xs:documentation>
+					<xs:documentation>For example, a page providing details related to GDPR. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List74">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 74">Language code – ISO 639-2/B</xs:documentation>
+			<xs:documentation source="ONIX Code List 74">Language – based on ISO 639-2/B</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="aar">
@@ -11706,10 +8711,28 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="ckb">
+				<xs:annotation>
+					<xs:documentation>Central Kurdish (Sorani)</xs:documentation>
+					<xs:documentation>ONIX local code, equivalent to ckb in ISO 639-3. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="cmc">
 				<xs:annotation>
 					<xs:documentation>Chamic languages</xs:documentation>
 					<xs:documentation>Collective name</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cmn">
+				<xs:annotation>
+					<xs:documentation>Mandarin</xs:documentation>
+					<xs:documentation>ONIX local code, equivalent to cmn in ISO 639-3</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cnr">
+				<xs:annotation>
+					<xs:documentation>Montenegrin</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="cop">
@@ -12960,6 +9983,12 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="mwf">
+				<xs:annotation>
+					<xs:documentation>Murrinh-Patha</xs:documentation>
+					<xs:documentation>ONIX local code, equivalent to mwf in ISO 639-3. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="mwl">
 				<xs:annotation>
 					<xs:documentation>Mirandese</xs:documentation>
@@ -13262,8 +10291,14 @@
 			</xs:enumeration>
 			<xs:enumeration value="per">
 				<xs:annotation>
-					<xs:documentation>Persian</xs:documentation>
+					<xs:documentation>Persian; Farsi</xs:documentation>
 					<xs:documentation>Macrolanguage</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pes">
+				<xs:annotation>
+					<xs:documentation>Iranian Persian; Parsi</xs:documentation>
+					<xs:documentation>ONIX local code, equivalent to pes in ISO 639-3. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="phi">
@@ -13314,6 +10349,12 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="prs">
+				<xs:annotation>
+					<xs:documentation>Dari; Afghan Persian</xs:documentation>
+					<xs:documentation>ONIX local code, equivalent to prs in ISO 639-3. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="pus">
 				<xs:annotation>
 					<xs:documentation>Pushto; Pashto</xs:documentation>
@@ -13330,6 +10371,18 @@
 				<xs:annotation>
 					<xs:documentation>Valencian</xs:documentation>
 					<xs:documentation>ONIX local code, distinct dialect of Catalan (not distinguished from cat by ISO 639-3)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="qlk">
+				<xs:annotation>
+					<xs:documentation>Lemko</xs:documentation>
+					<xs:documentation>ONIX local code, distinct dialect of of Rusyn (not distinguished from rue by ISO 639-3). For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="qls">
+				<xs:annotation>
+					<xs:documentation>Neutral Latin American Spanish</xs:documentation>
+					<xs:documentation>ONIX local code, distinct and exclusively spoken variation of Spanish, not distinguished from spa (Spanish, Castilian) by ISO 639-3. Neutral Latin American Spanish should be considered a ‘shorthand’ for spa plus a ‘country code’ for Latin America – but prefer spa plus the relevant country code for specifically Mexican Spanish, Argentine (Rioplatense) Spanish, Puerto Rican Spanish etc. Neutral Latin American Spanish must only be used with audio material (including the audio tracks of TV, video and film) to indicate use of accent, vocabulary and construction suitable for broad use across Latin America. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="que">
@@ -13466,7 +10519,7 @@
 			</xs:enumeration>
 			<xs:enumeration value="sco">
 				<xs:annotation>
-					<xs:documentation>Scots (lallans)</xs:documentation>
+					<xs:documentation>Scots</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
@@ -13772,7 +10825,7 @@
 			</xs:enumeration>
 			<xs:enumeration value="tgk">
 				<xs:annotation>
-					<xs:documentation>Tajik</xs:documentation>
+					<xs:documentation>Tajik; Tajiki Persian</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
@@ -14094,6 +11147,12 @@
 					<xs:documentation>Collective name</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="yue">
+				<xs:annotation>
+					<xs:documentation>Cantonese</xs:documentation>
+					<xs:documentation>ONIX local code, equivalent to yue in ISO 639-3</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="zap">
 				<xs:annotation>
 					<xs:documentation>Zapotec</xs:documentation>
@@ -14156,28 +11215,9 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="List75">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 75">Person date role</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="007">
-				<xs:annotation>
-					<xs:documentation>Date of birth</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="008">
-				<xs:annotation>
-					<xs:documentation>Date of death</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="List76">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 76">Product form feature value – DVD region codes</xs:documentation>
+			<xs:documentation source="ONIX Code List 76">DVD region</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="0">
@@ -14375,1237 +11415,6 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="List78">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 78">Product form detail</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="A101">
-				<xs:annotation>
-					<xs:documentation>CD standard audio format</xs:documentation>
-					<xs:documentation>CD ‘red book’ format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A102">
-				<xs:annotation>
-					<xs:documentation>SACD super audio format</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A103">
-				<xs:annotation>
-					<xs:documentation>MP3 format</xs:documentation>
-					<xs:documentation>MPEG-1/2 Audio Layer III file</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A104">
-				<xs:annotation>
-					<xs:documentation>WAV format</xs:documentation>
-					<xs:documentation>Waveform audio file</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A105">
-				<xs:annotation>
-					<xs:documentation>Real Audio format</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A106">
-				<xs:annotation>
-					<xs:documentation>WMA</xs:documentation>
-					<xs:documentation>Windows Media Audio format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A107">
-				<xs:annotation>
-					<xs:documentation>AAC</xs:documentation>
-					<xs:documentation>Advanced Audio Coding format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A108">
-				<xs:annotation>
-					<xs:documentation>Ogg/Vorbis</xs:documentation>
-					<xs:documentation>Vorbis audio format in the Ogg container</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A109">
-				<xs:annotation>
-					<xs:documentation>Audible</xs:documentation>
-					<xs:documentation>Audio format proprietary to Audible.com</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A110">
-				<xs:annotation>
-					<xs:documentation>FLAC</xs:documentation>
-					<xs:documentation>Free lossless audio codec</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A111">
-				<xs:annotation>
-					<xs:documentation>AIFF</xs:documentation>
-					<xs:documentation>Audio Interchangeable File Format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A112">
-				<xs:annotation>
-					<xs:documentation>ALAC</xs:documentation>
-					<xs:documentation>Apple Lossless Audio Codec</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A201">
-				<xs:annotation>
-					<xs:documentation>DAISY 2: full audio with title only (no navigation)</xs:documentation>
-					<xs:documentation>Deprecated, as does not meet DAISY 2 standard. Use conventional audiobook codes instead</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A202">
-				<xs:annotation>
-					<xs:documentation>DAISY 2: full audio with navigation (no text)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A203">
-				<xs:annotation>
-					<xs:documentation>DAISY 2: full audio with navigation and partial text</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A204">
-				<xs:annotation>
-					<xs:documentation>DAISY 2: full audio with navigation and full text</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A205">
-				<xs:annotation>
-					<xs:documentation>DAISY 2: full text with navigation and partial audio</xs:documentation>
-					<xs:documentation>Reading systems may provide full audio via text-to-speech</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A206">
-				<xs:annotation>
-					<xs:documentation>DAISY 2: full text with navigation and no audio</xs:documentation>
-					<xs:documentation>Reading systems may provide full audio via text-to-speech</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A207">
-				<xs:annotation>
-					<xs:documentation>DAISY 3: full audio with title only (no navigation)</xs:documentation>
-					<xs:documentation>Deprecated, as does not meet DAISY 3 standard. Use conventional audiobook codes instead</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A208">
-				<xs:annotation>
-					<xs:documentation>DAISY 3: full audio with navigation (no text)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A209">
-				<xs:annotation>
-					<xs:documentation>DAISY 3: full audio with navigation and partial text</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A210">
-				<xs:annotation>
-					<xs:documentation>DAISY 3: full audio with navigation and full text</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A211">
-				<xs:annotation>
-					<xs:documentation>DAISY 3: full text with navigation and some audio</xs:documentation>
-					<xs:documentation>Reading systems may provide full audio via text-to-speech</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A212">
-				<xs:annotation>
-					<xs:documentation>DAISY 3: full text with navigation (no audio)</xs:documentation>
-					<xs:documentation>Reading systems may provide full audio via text-to-speech</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A301">
-				<xs:annotation>
-					<xs:documentation>Standalone audio</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A302">
-				<xs:annotation>
-					<xs:documentation>Readalong audio</xs:documentation>
-					<xs:documentation>Audio intended exclusively for use alongside a printed copy of the book. Most often a children’s product. Normally contains instructions such as ‘turn the page now’ and other references to the printed item, and is usually sold packaged together with a printed copy</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A303">
-				<xs:annotation>
-					<xs:documentation>Playalong audio</xs:documentation>
-					<xs:documentation>Audio intended for musical accompaniment, eg ‘Music minus one’, etc, often used for music learning. Includes singalong backing audio for musical learning or for Karaoke-style entertainment</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A304">
-				<xs:annotation>
-					<xs:documentation>Speakalong audio</xs:documentation>
-					<xs:documentation>Audio intended for language learning, which includes speech plus gaps intended to be filled by the listener</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A305">
-				<xs:annotation>
-					<xs:documentation>Synchronised audio</xs:documentation>
-					<xs:documentation>Audio synchronised to text within an e-publication, for example an EPUB3 with audio overlay. Synchronisation at least at paragraph level, and covering the full content</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A410">
-				<xs:annotation>
-					<xs:documentation>Mono</xs:documentation>
-					<xs:documentation>Includes 'stereo' where channels are identical</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A420">
-				<xs:annotation>
-					<xs:documentation>Stereo</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A421">
-				<xs:annotation>
-					<xs:documentation>Stereo 2.1</xs:documentation>
-					<xs:documentation>Stereo plus low-frequency channel</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A441">
-				<xs:annotation>
-					<xs:documentation>Surround 4.1</xs:documentation>
-					<xs:documentation>Five-channel audio (including low-frequency channel)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="A451">
-				<xs:annotation>
-					<xs:documentation>Surround 5.1</xs:documentation>
-					<xs:documentation>Six-channel audio (including low-frequency channel)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B101">
-				<xs:annotation>
-					<xs:documentation>Mass market (rack) paperback</xs:documentation>
-					<xs:documentation>In North America, a category of paperback characterized partly by page size (typically 4¼ x 7 1/8 inches) and partly by target market and terms of trade. Use with Product Form code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B102">
-				<xs:annotation>
-					<xs:documentation>Trade paperback (US)</xs:documentation>
-					<xs:documentation>In North America, a category of paperback characterized partly by page size and partly by target market and terms of trade. AKA ‘quality paperback’, and including textbooks. Most paperback books sold in North America except ‘mass-market’ (B101) and ‘tall rack’ (B107) are correctly described with this code. Use with Product Form code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B103">
-				<xs:annotation>
-					<xs:documentation>Digest format paperback</xs:documentation>
-					<xs:documentation>In North America, a category of paperback characterized by page size and generally used for children’s books; use with Product Form code BC. Note: was wrongly shown as B102 (duplicate entry) in Issue 3</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B104">
-				<xs:annotation>
-					<xs:documentation>A-format paperback</xs:documentation>
-					<xs:documentation>In UK, a category of paperback characterized by page size (normally 178 x 111 mm approx); use with Product Form code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B105">
-				<xs:annotation>
-					<xs:documentation>B-format paperback</xs:documentation>
-					<xs:documentation>In UK, a category of paperback characterized by page size (normally 198 x 129 mm approx); use with Product Form code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B106">
-				<xs:annotation>
-					<xs:documentation>Trade paperback (UK)</xs:documentation>
-					<xs:documentation>In UK, a category of paperback characterized partly by size (usually in traditional hardback dimensions), and often used for paperback originals; use with Product Form code BC (replaces ‘C-format’ from former List 8)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B107">
-				<xs:annotation>
-					<xs:documentation>Tall rack paperback (US)</xs:documentation>
-					<xs:documentation>In North America, a category of paperback characterised partly by page size and partly by target market and terms of trade; use with Product Form code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B108">
-				<xs:annotation>
-					<xs:documentation>A5 size Tankobon</xs:documentation>
-					<xs:documentation>210x148mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B109">
-				<xs:annotation>
-					<xs:documentation>JIS B5 size Tankobon</xs:documentation>
-					<xs:documentation>Japanese B-series size, 257x182mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B110">
-				<xs:annotation>
-					<xs:documentation>JIS B6 size Tankobon</xs:documentation>
-					<xs:documentation>Japanese B-series size, 182x128mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B111">
-				<xs:annotation>
-					<xs:documentation>A6 size Bunko</xs:documentation>
-					<xs:documentation>148x105mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B112">
-				<xs:annotation>
-					<xs:documentation>B40-dori Shinsho</xs:documentation>
-					<xs:documentation>Japanese format, 182x103mm or 173x105mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B113">
-				<xs:annotation>
-					<xs:documentation>Pocket (Sweden, Norway, France)</xs:documentation>
-					<xs:documentation>A Swedish, Norwegian, French paperback format, of no particular fixed size. Use with Product Form Code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B114">
-				<xs:annotation>
-					<xs:documentation>Storpocket (Sweden)</xs:documentation>
-					<xs:documentation>A Swedish paperback format, use with Product Form Code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B115">
-				<xs:annotation>
-					<xs:documentation>Kartonnage (Sweden)</xs:documentation>
-					<xs:documentation>A Swedish hardback format, use with Product Form Code BB</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B116">
-				<xs:annotation>
-					<xs:documentation>Flexband (Sweden)</xs:documentation>
-					<xs:documentation>A Swedish softback format, use with Product Form Code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B117">
-				<xs:annotation>
-					<xs:documentation>Mook / Bookazine</xs:documentation>
-					<xs:documentation>A softback book in the format of a magazine, usually sold like a book. Use with Product Form code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B118">
-				<xs:annotation>
-					<xs:documentation>Dwarsligger</xs:documentation>
-					<xs:documentation>Also called ‘Flipback’. A softback book in a specially compact proprietary format with pages printed in landscape on very thin paper and bound along the long (top) edge – see www.dwarsligger.com</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B119">
-				<xs:annotation>
-					<xs:documentation>46 size</xs:documentation>
-					<xs:documentation>Japanese format: 188x127mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B120">
-				<xs:annotation>
-					<xs:documentation>46-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B121">
-				<xs:annotation>
-					<xs:documentation>A4</xs:documentation>
-					<xs:documentation>297x210mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B122">
-				<xs:annotation>
-					<xs:documentation>A4-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B123">
-				<xs:annotation>
-					<xs:documentation>A5-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B124">
-				<xs:annotation>
-					<xs:documentation>B5-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B125">
-				<xs:annotation>
-					<xs:documentation>B6-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B126">
-				<xs:annotation>
-					<xs:documentation>AB size</xs:documentation>
-					<xs:documentation>257x210mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B127">
-				<xs:annotation>
-					<xs:documentation>JIS B7 size</xs:documentation>
-					<xs:documentation>Japanese B-series size, 128x91mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B128">
-				<xs:annotation>
-					<xs:documentation>Kiku size</xs:documentation>
-					<xs:documentation>Japanese format, 218x152mm or 227x152mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B129">
-				<xs:annotation>
-					<xs:documentation>Kiku-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B130">
-				<xs:annotation>
-					<xs:documentation>JIS B4 size</xs:documentation>
-					<xs:documentation>Japanese B-series size, 364x257mm</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B131">
-				<xs:annotation>
-					<xs:documentation>Paperback (DE)</xs:documentation>
-					<xs:documentation>German paperback format, greater than 205mm high, with flaps. Use with Product form code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B201">
-				<xs:annotation>
-					<xs:documentation>Coloring / join-the-dot book</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B202">
-				<xs:annotation>
-					<xs:documentation>Lift-the-flap book</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B203">
-				<xs:annotation>
-					<xs:documentation>Fuzzy book</xs:documentation>
-					<xs:documentation>DEPRECATED because of ambiguity – use B210, B214 or B215 as appropriate</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B204">
-				<xs:annotation>
-					<xs:documentation>Miniature book</xs:documentation>
-					<xs:documentation>Note: was wrongly shown as B203 (duplicate entry) in Issue 3</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B205">
-				<xs:annotation>
-					<xs:documentation>Moving picture / flicker book</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B206">
-				<xs:annotation>
-					<xs:documentation>Pop-up book</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B207">
-				<xs:annotation>
-					<xs:documentation>Scented / ‘smelly’ book</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B208">
-				<xs:annotation>
-					<xs:documentation>Sound story / ‘noisy’ book</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B209">
-				<xs:annotation>
-					<xs:documentation>Sticker book</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B210">
-				<xs:annotation>
-					<xs:documentation>Touch-and-feel book</xs:documentation>
-					<xs:documentation>A book whose pages have a variety of textured inserts designed to stimulate tactile exploration: see also B214 and B215</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B211">
-				<xs:annotation>
-					<xs:documentation>Toy / die-cut book</xs:documentation>
-					<xs:documentation>DEPRECATED – use B212 or B213 as appropriate</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B212">
-				<xs:annotation>
-					<xs:documentation>Die-cut book</xs:documentation>
-					<xs:documentation>A book which is cut into a distinctive non-rectilinear shape and/or in which holes or shapes have been cut internally. (‘Die-cut’ is used here as a convenient shorthand, and does not imply strict limitation to a particular production process)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B213">
-				<xs:annotation>
-					<xs:documentation>Book-as-toy</xs:documentation>
-					<xs:documentation>A book which is also a toy, or which incorporates a toy as an integral part. (Do not, however, use B213 for a multiple-item product which includes a book and a toy as separate items)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B214">
-				<xs:annotation>
-					<xs:documentation>Soft-to-touch book</xs:documentation>
-					<xs:documentation>A book whose cover has a soft textured finish, typically over board</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B215">
-				<xs:annotation>
-					<xs:documentation>Fuzzy-felt book</xs:documentation>
-					<xs:documentation>A book with detachable felt pieces and textured pages on which they can be arranged</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B221">
-				<xs:annotation>
-					<xs:documentation>Picture book</xs:documentation>
-					<xs:documentation>Children’s picture book: use with applicable Product Form code</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B222">
-				<xs:annotation>
-					<xs:documentation>‘Carousel’ book</xs:documentation>
-					<xs:documentation>(aka ‘Star’ book). Tax treatment of products may differ from that of products with similar codes such as Book as toy or Pop-up book)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B301">
-				<xs:annotation>
-					<xs:documentation>Loose leaf – sheets and binder</xs:documentation>
-					<xs:documentation>Use with Product Form code BD</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B302">
-				<xs:annotation>
-					<xs:documentation>Loose leaf – binder only</xs:documentation>
-					<xs:documentation>Use with Product Form code BD</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B303">
-				<xs:annotation>
-					<xs:documentation>Loose leaf – sheets only</xs:documentation>
-					<xs:documentation>Use with Product Form code BD</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B304">
-				<xs:annotation>
-					<xs:documentation>Sewn</xs:documentation>
-					<xs:documentation>AKA stitched; for ‘saddle-sewn’, see code B310</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B305">
-				<xs:annotation>
-					<xs:documentation>Unsewn / adhesive bound</xs:documentation>
-					<xs:documentation>Including ‘perfect bound’, ‘glued’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B306">
-				<xs:annotation>
-					<xs:documentation>Library binding</xs:documentation>
-					<xs:documentation>Strengthened cloth-over-boards binding intended for libraries: use with Product form code BB</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B307">
-				<xs:annotation>
-					<xs:documentation>Reinforced binding</xs:documentation>
-					<xs:documentation>Strengthened binding, not specifically intended for libraries</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B308">
-				<xs:annotation>
-					<xs:documentation>Half bound</xs:documentation>
-					<xs:documentation>Must be accompanied by a code specifiying a material, eg ‘half-bound real leather’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B309">
-				<xs:annotation>
-					<xs:documentation>Quarter bound</xs:documentation>
-					<xs:documentation>Must be accompanied by a code specifiying a material, eg ‘quarter bound real leather’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B310">
-				<xs:annotation>
-					<xs:documentation>Saddle-sewn</xs:documentation>
-					<xs:documentation>AKA ‘saddle-stitched’ or ‘wire-stitched’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B311">
-				<xs:annotation>
-					<xs:documentation>Comb bound</xs:documentation>
-					<xs:documentation>Round or oval plastic forms in a clamp-like configuration: use with Product Form code BE</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B312">
-				<xs:annotation>
-					<xs:documentation>Wire-O</xs:documentation>
-					<xs:documentation>Twin loop metal wire spine: use with Product Form code BE</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B313">
-				<xs:annotation>
-					<xs:documentation>Concealed wire</xs:documentation>
-					<xs:documentation>Cased over Coiled or Wire-O binding: use with Product Form code BE and Product Form Detail code B312 or B315</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B314">
-				<xs:annotation>
-					<xs:documentation>Coiled wire bound</xs:documentation>
-					<xs:documentation>Spiral wire bound. Use with product form code BE. The default if a spiral binding type is not stated. Cf. Comb and Wire-O binding</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B315">
-				<xs:annotation>
-					<xs:documentation>Trade binding</xs:documentation>
-					<xs:documentation>Hardcover binding intended for general consumers rather than libraries, use with Product form code BB. The default if a hardcover binding detail is not stated. cf. Library binding</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B400">
-				<xs:annotation>
-					<xs:documentation>Self-cover</xs:documentation>
-					<xs:documentation>Covers do not use a distinctive stock, but are the same as the body pages</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B401">
-				<xs:annotation>
-					<xs:documentation>Cloth over boards</xs:documentation>
-					<xs:documentation>AKA fabric, linen over boards</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B402">
-				<xs:annotation>
-					<xs:documentation>Paper over boards</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B403">
-				<xs:annotation>
-					<xs:documentation>Leather, real</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B404">
-				<xs:annotation>
-					<xs:documentation>Leather, imitation</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B405">
-				<xs:annotation>
-					<xs:documentation>Leather, bonded</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B406">
-				<xs:annotation>
-					<xs:documentation>Vellum</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B407">
-				<xs:annotation>
-					<xs:documentation>Plastic</xs:documentation>
-					<xs:documentation>DEPRECATED – use new B412 or B413 as appropriate</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B408">
-				<xs:annotation>
-					<xs:documentation>Vinyl</xs:documentation>
-					<xs:documentation>DEPRECATED – use new B412 or B414 as appropriate</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B409">
-				<xs:annotation>
-					<xs:documentation>Cloth</xs:documentation>
-					<xs:documentation>Cloth, not necessarily over boards – cf B401</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B410">
-				<xs:annotation>
-					<xs:documentation>Imitation cloth</xs:documentation>
-					<xs:documentation>Spanish ‘simil-tela’</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B411">
-				<xs:annotation>
-					<xs:documentation>Velvet</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B412">
-				<xs:annotation>
-					<xs:documentation>Flexible plastic/vinyl cover</xs:documentation>
-					<xs:documentation>AKA ‘flexibound’: use with Product Form code BC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B413">
-				<xs:annotation>
-					<xs:documentation>Plastic-covered</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B414">
-				<xs:annotation>
-					<xs:documentation>Vinyl-covered</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B415">
-				<xs:annotation>
-					<xs:documentation>Laminated cover</xs:documentation>
-					<xs:documentation>Book, laminating material unspecified: use L101 for ‘whole product laminated’, eg a laminated sheet map or wallchart</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B416">
-				<xs:annotation>
-					<xs:documentation>Card cover</xs:documentation>
-					<xs:documentation>With card cover (like a typical paperback). As distinct from a self-cover or more elaborate binding</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B501">
-				<xs:annotation>
-					<xs:documentation>With dust jacket</xs:documentation>
-					<xs:documentation>Type unspecified</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B502">
-				<xs:annotation>
-					<xs:documentation>With printed dust jacket</xs:documentation>
-					<xs:documentation>Used to distinguish from B503</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B503">
-				<xs:annotation>
-					<xs:documentation>With translucent dust cover</xs:documentation>
-					<xs:documentation>With translucent paper or plastic protective cover</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B504">
-				<xs:annotation>
-					<xs:documentation>With flaps</xs:documentation>
-					<xs:documentation>For paperback with flaps</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B505">
-				<xs:annotation>
-					<xs:documentation>With thumb index</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B506">
-				<xs:annotation>
-					<xs:documentation>With ribbon marker(s)</xs:documentation>
-					<xs:documentation>If the number of markers is significant, it can be stated as free text in &lt;ProductFormDescription&gt;</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B507">
-				<xs:annotation>
-					<xs:documentation>With zip fastener</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B508">
-				<xs:annotation>
-					<xs:documentation>With button snap fastener</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B509">
-				<xs:annotation>
-					<xs:documentation>With leather edge lining</xs:documentation>
-					<xs:documentation>AKA yapp edge?</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B510">
-				<xs:annotation>
-					<xs:documentation>Rough front</xs:documentation>
-					<xs:documentation>With edge trimming such that the front edge is ragged, not neatly and squarely trimmed: AKA deckle edge, feather edge, uncut edge, rough cut</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B511">
-				<xs:annotation>
-					<xs:documentation>With foldout</xs:documentation>
-					<xs:documentation>With one or more gatefold or foldout sections bound in</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B512">
-				<xs:annotation>
-					<xs:documentation>Wide margin</xs:documentation>
-					<xs:documentation>Pages include extra-wide margin specifically intended for hand-written annotations</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B513">
-				<xs:annotation>
-					<xs:documentation>With fastening strap</xs:documentation>
-					<xs:documentation>Book with attached loop for fixing to baby stroller, cot, chair etc</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B514">
-				<xs:annotation>
-					<xs:documentation>With perforated pages</xs:documentation>
-					<xs:documentation>With one or more pages perforated and intended to be torn out for use</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B601">
-				<xs:annotation>
-					<xs:documentation>Turn-around book</xs:documentation>
-					<xs:documentation>A book in which half the content is printed upside-down, to be read the other way round. Also known as a ‘flip-book’, ‘back-to-back’, (fr.) ‘tête-bêche’ (usually an omnibus of two works)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B602">
-				<xs:annotation>
-					<xs:documentation>Unflipped manga format</xs:documentation>
-					<xs:documentation>Manga with pages and panels in the sequence of the original Japanese, but with Western text</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B610">
-				<xs:annotation>
-					<xs:documentation>Syllabification</xs:documentation>
-					<xs:documentation>Text shows syllable breaks</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B701">
-				<xs:annotation>
-					<xs:documentation>UK Uncontracted Braille</xs:documentation>
-					<xs:documentation>Single letters only. Was formerly identified as UK Braille Grade 1</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B702">
-				<xs:annotation>
-					<xs:documentation>UK Contracted Braille</xs:documentation>
-					<xs:documentation>With some letter combinations. Was formerly identified as UK Braille Grade 2</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B703">
-				<xs:annotation>
-					<xs:documentation>US Braille</xs:documentation>
-					<xs:documentation>DEPRECATED- use B704/B705 as appropriate instead</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B704">
-				<xs:annotation>
-					<xs:documentation>US Uncontracted Braille</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B705">
-				<xs:annotation>
-					<xs:documentation>US Contracted Braille</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B706">
-				<xs:annotation>
-					<xs:documentation>Unified English Braille</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="B707">
-				<xs:annotation>
-					<xs:documentation>Moon</xs:documentation>
-					<xs:documentation>Moon embossed alphabet, used by some print-impaired readers who have difficulties with Braille</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D101">
-				<xs:annotation>
-					<xs:documentation>Real Video format</xs:documentation>
-					<xs:documentation>Includes RealVideo packaged within a .rm RealMedia container</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D102">
-				<xs:annotation>
-					<xs:documentation>Quicktime format</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D103">
-				<xs:annotation>
-					<xs:documentation>AVI format</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D104">
-				<xs:annotation>
-					<xs:documentation>Windows Media Video format</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D105">
-				<xs:annotation>
-					<xs:documentation>MPEG-4</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D201">
-				<xs:annotation>
-					<xs:documentation>MS-DOS</xs:documentation>
-					<xs:documentation>Use with an applicable Product Form code D*; note that more detail of operating system requirements can be given in a Product Form Feature composite</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D202">
-				<xs:annotation>
-					<xs:documentation>Windows</xs:documentation>
-					<xs:documentation>Use with an applicable Product Form code D*; see note on D201</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D203">
-				<xs:annotation>
-					<xs:documentation>Macintosh</xs:documentation>
-					<xs:documentation>Use with an applicable Product Form code D*; see note on D201</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D204">
-				<xs:annotation>
-					<xs:documentation>UNIX / LINUX</xs:documentation>
-					<xs:documentation>Use with an applicable Product Form code D*; see note on D201</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D205">
-				<xs:annotation>
-					<xs:documentation>Other operating system(s)</xs:documentation>
-					<xs:documentation>Use with an applicable Product Form code D*; see note on D201</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D206">
-				<xs:annotation>
-					<xs:documentation>Palm OS</xs:documentation>
-					<xs:documentation>Use with an applicable Product Form code D*; see note on D201</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D207">
-				<xs:annotation>
-					<xs:documentation>Windows Mobile</xs:documentation>
-					<xs:documentation>Use with an applicable Product Form code D*; see note on D201</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D301">
-				<xs:annotation>
-					<xs:documentation>Microsoft XBox</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D302">
-				<xs:annotation>
-					<xs:documentation>Nintendo Gameboy Color</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D303">
-				<xs:annotation>
-					<xs:documentation>Nintendo Gameboy Advanced</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D304">
-				<xs:annotation>
-					<xs:documentation>Nintendo Gameboy</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D305">
-				<xs:annotation>
-					<xs:documentation>Nintendo Gamecube</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D306">
-				<xs:annotation>
-					<xs:documentation>Nintendo 64</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D307">
-				<xs:annotation>
-					<xs:documentation>Sega Dreamcast</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D308">
-				<xs:annotation>
-					<xs:documentation>Sega Genesis/Megadrive</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D309">
-				<xs:annotation>
-					<xs:documentation>Sega Saturn</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D310">
-				<xs:annotation>
-					<xs:documentation>Sony PlayStation 1</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D311">
-				<xs:annotation>
-					<xs:documentation>Sony PlayStation 2</xs:documentation>
-					<xs:documentation>Use with Product Form code DE or DB as applicable</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D312">
-				<xs:annotation>
-					<xs:documentation>Nintendo Dual Screen</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D313">
-				<xs:annotation>
-					<xs:documentation>Sony PlayStation 3</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D314">
-				<xs:annotation>
-					<xs:documentation>Xbox 360</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D315">
-				<xs:annotation>
-					<xs:documentation>Nintendo Wii</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="D316">
-				<xs:annotation>
-					<xs:documentation>Sony PlayStation Portable (PSP)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E200">
-				<xs:annotation>
-					<xs:documentation>Reflowable</xs:documentation>
-					<xs:documentation>Use where a particular e-publication type (specified in &lt;EpubType&gt;) has both reflowable and fixed-format variants</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E201">
-				<xs:annotation>
-					<xs:documentation>Fixed format</xs:documentation>
-					<xs:documentation>Use where a particular e-publication type (specified in &lt;EpubType&gt;) has both reflowable and fixed-format variants</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E202">
-				<xs:annotation>
-					<xs:documentation>Readable offline</xs:documentation>
-					<xs:documentation>All e-publication resources are included within the e-publication package</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E203">
-				<xs:annotation>
-					<xs:documentation>Requires network connection</xs:documentation>
-					<xs:documentation>E-publication requires a network connection to access some resources (eg an enhanced e-book where video clips are not stored within the e-publication ‘package’ itself, but are delivered via an internet connection)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E204">
-				<xs:annotation>
-					<xs:documentation>Content removed</xs:documentation>
-					<xs:documentation>Resources (eg images) present in other editions have been removed from this product, eg due to rights issues</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E210">
-				<xs:annotation>
-					<xs:documentation>Landscape</xs:documentation>
-					<xs:documentation>Use for fixed-format e-books optimised for landscape display. Also include an indication of the optimal screen aspect ratio</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E211">
-				<xs:annotation>
-					<xs:documentation>Portrait</xs:documentation>
-					<xs:documentation>Use for fixed-format e-books optimised for portrait display. Also include an indication of the optimal screen aspect ratio</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E221">
-				<xs:annotation>
-					<xs:documentation>5:4</xs:documentation>
-					<xs:documentation>Use for fixed-format e-books optimised for displays with a 5:4 aspect ratio (eg 1280x1024 pixels etc, assuming square pixels). Note that aspect ratio codes are NOT specific to actual screen dimensions or pixel counts, but to the ratios between two dimensions or two pixel counts</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E222">
-				<xs:annotation>
-					<xs:documentation>4:3</xs:documentation>
-					<xs:documentation>Use for fixed-format e-books optimised for displays with a 4:3 aspect ratio (eg 800x600, 1024x768, 2048x1536 pixels etc)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E223">
-				<xs:annotation>
-					<xs:documentation>3:2</xs:documentation>
-					<xs:documentation>Use for fixed-format e-books optimised for displays with a 3:2 aspect ratio (eg 960x640, 3072x2048 pixels etc)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E224">
-				<xs:annotation>
-					<xs:documentation>16:10</xs:documentation>
-					<xs:documentation>Use for fixed-format e-books optimised for displays with a 16:10 aspect ratio (eg 1440x900, 2560x1600 pixels etc)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="E225">
-				<xs:annotation>
-					<xs:documentation>16:9</xs:documentation>
-					<xs:documentation>Use for fixed-format e-books optimised for displays with a 16:9 aspect ratio (eg 1024x576, 1920x1080, 2048x1152 pixels etc)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="L101">
-				<xs:annotation>
-					<xs:documentation>Laminated</xs:documentation>
-					<xs:documentation>Whole product laminated (eg laminated map, fold-out chart, wallchart, etc): use B415 for book with laminated cover</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P101">
-				<xs:annotation>
-					<xs:documentation>Desk calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P102">
-				<xs:annotation>
-					<xs:documentation>Mini calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P103">
-				<xs:annotation>
-					<xs:documentation>Engagement calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P104">
-				<xs:annotation>
-					<xs:documentation>Day by day calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P105">
-				<xs:annotation>
-					<xs:documentation>Poster calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P106">
-				<xs:annotation>
-					<xs:documentation>Wall calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P107">
-				<xs:annotation>
-					<xs:documentation>Perpetual calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P108">
-				<xs:annotation>
-					<xs:documentation>Advent calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P109">
-				<xs:annotation>
-					<xs:documentation>Bookmark calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P110">
-				<xs:annotation>
-					<xs:documentation>Student calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P111">
-				<xs:annotation>
-					<xs:documentation>Project calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P112">
-				<xs:annotation>
-					<xs:documentation>Almanac calendar</xs:documentation>
-					<xs:documentation>Use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P113">
-				<xs:annotation>
-					<xs:documentation>Other calendar</xs:documentation>
-					<xs:documentation>A calendar that is not one of the types specified elsewhere: use with Product Form code PC</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P114">
-				<xs:annotation>
-					<xs:documentation>Other calendar or organiser product</xs:documentation>
-					<xs:documentation>A product that is associated with or ancillary to a calendar or organiser, eg a deskstand for a calendar, or an insert for an organiser: use with Product Form code PC or PS</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P120">
-				<xs:annotation>
-					<xs:documentation>Picture story cards</xs:documentation>
-					<xs:documentation>Kamishibai / Cantastoria cards</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P201">
-				<xs:annotation>
-					<xs:documentation>Hardback (stationery)</xs:documentation>
-					<xs:documentation>Stationery item in hardback book format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P202">
-				<xs:annotation>
-					<xs:documentation>Paperback / softback (stationery)</xs:documentation>
-					<xs:documentation>Stationery item in paperback/softback book format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P203">
-				<xs:annotation>
-					<xs:documentation>Spiral bound (stationery)</xs:documentation>
-					<xs:documentation>Stationery item in spiral-bound book format</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P204">
-				<xs:annotation>
-					<xs:documentation>Leather / fine binding (stationery)</xs:documentation>
-					<xs:documentation>Stationery item in leather-bound book format, or other fine binding</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="P301">
-				<xs:annotation>
-					<xs:documentation>With hanging strips</xs:documentation>
-					<xs:documentation>For map, poster, wallchart etc</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="V201">
-				<xs:annotation>
-					<xs:documentation>PAL</xs:documentation>
-					<xs:documentation>TV standard for video or DVD</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="V202">
-				<xs:annotation>
-					<xs:documentation>NTSC</xs:documentation>
-					<xs:documentation>TV standard for video or DVD</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="V203">
-				<xs:annotation>
-					<xs:documentation>SECAM</xs:documentation>
-					<xs:documentation>TV standard for video or DVD</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="V220">
-				<xs:annotation>
-					<xs:documentation>Home use</xs:documentation>
-					<xs:documentation>Licensed for use in domestic contexts only</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="V221">
-				<xs:annotation>
-					<xs:documentation>Classroom use</xs:documentation>
-					<xs:documentation>Licensed for use in education</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="List79">
 		<xs:annotation>
 			<xs:documentation source="ONIX Code List 79">Product form feature type</xs:documentation>
@@ -15656,7 +11465,7 @@
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>‘Point and listen’ device compatibility</xs:documentation>
-					<xs:documentation>Indicates compatibility with proprietary ‘point and listen’ devices such as Ting Pen (http://www.ting.eu) or the iSmart Touch and Read Pen. These devices scan invisible codes specially printed on the page to identify the book and position of the word, and the word is then read aloud by the device. The name of the compatible device (or range of devices) should be given in &lt;ProductFormFeatureDescription&gt;</xs:documentation>
+					<xs:documentation>Indicates compatibility with proprietary ‘point and listen’ devices such as Ting Pen (http://www.ting.eu), the iSmart Touch and Read Pen. These devices scan invisible codes specially printed on the page to identify the book and position of the word, and the word is then read aloud by the device. The name of the compatible device (or range of devices) should be given in &lt;ProductFormFeatureDescription&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
@@ -15669,12 +11478,6 @@
 				<xs:annotation>
 					<xs:documentation>E-publication format version</xs:documentation>
 					<xs:documentation>For versioned e-book file formats (or in some cases, devices). &lt;ProductFormFeatureValue&gt; should contain the version number as a period-separated list of numbers (eg ‘7’, ‘1.5’ or ‘3.10.7’). Use only with ONIX 3.0 – in ONIX 2.1, use &lt;EpubTypeVersion&gt; instead. For the most common file formats, code 15 and List 220 is strongly preferred</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="11">
-				<xs:annotation>
-					<xs:documentation>CPSIA choking hazard warning</xs:documentation>
-					<xs:documentation>DEPRECATED – use code 12 and List 143</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="12">
@@ -15707,40 +11510,70 @@
 					<xs:documentation>For common versioned e-book formats, the name and version of the validator used to check conformance. &lt;ProductFormFeatureDescription&gt; is the common name of the validator used (eg EpubCheck, Flightdeck), and &lt;ProductFormFeatureValue&gt; is the version number of the validator (eg 4.0.0a). Use with code 15 (or possibly code 10), or with &lt;EpubTypeVersion&gt;, to specify the version the e-publication conforms with</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>‘Point and watch’ device/app compatibility</xs:documentation>
+					<xs:documentation>Indicates compatibility with proprietary ‘point and watch‘ devices or apps. These scan invisible codes specially printed on the page, or the whole page image, to identify the book and page position. Scanning can trigger display of (for example) an augmented reality view of the page. The name of the compatible app or device (or range of apps/devices) should be given in &lt;ProductFormFeatureDescription&gt;. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>E-publication authentication and access control</xs:documentation>
+					<xs:documentation>Requirement for user authentication prior to use, with detail of authentication method (user enrolment, and login passwords, location- or device-based recognition, authentication via third-party identity service etc) given in &lt;ProductFormFeatureDescription&gt;. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Battery type</xs:documentation>
+					<xs:documentation>Use to describe battery requirements, hazards and safety warnings. &lt;ProductFormFeatureValue&gt; is a code from List 242. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Battery capacity</xs:documentation>
+					<xs:documentation>Total capacity (of batteries in the product) in Watt hours. &lt;ProductFormFeatureValue&gt; is an integer or decimal number (eg ‘45’, not ‘45Wh’). For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Dangerous goods</xs:documentation>
+					<xs:documentation>Use to describe regulation of the product for various purposes. &lt;ProductFormFeatureValue&gt; is a code from List 243. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="30">
 				<xs:annotation>
 					<xs:documentation>Not FSC or PEFC certified</xs:documentation>
-					<xs:documentation>Product does not carry FSC or PEFC logo. The Product Form Feature Value and Description elements are not used. The product may, however, still carry a claimed Pre- and Post-Consumer Waste (PCW) content (type code 37) in a separate repeat of the Product Form Feature composite</xs:documentation>
+					<xs:documentation>Product does not carry FSC or PEFC logo. The Product Form Feature Value element is not used. The Product Form Feature Description element may carry free text indicating the grade or type of paper. The product record may also still carry a claimed Pre- and Post-Consumer Waste (PCW) percentage value (type code 37) in a separate repeat of the Product Form Feature composite</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="31">
 				<xs:annotation>
 					<xs:documentation>FSC certified – pure</xs:documentation>
-					<xs:documentation>Product carries FSC logo (Pure, 100%). &lt;ProductFormFeatureValue&gt; is the Certification number (ie either a Chain Of Custody (COC) number or a Trademark License number) printed on the book. Format: Chain of Custody number is two to five letters-COC-six digits (the digits should include leading zeros if necessary), eg ‘AB-COC-001234’ or ‘ABCDE-COC-123456’; Trademark License number is C followed by six digits, eg ‘C005678’ (this would normally be prefixed by ‘FSC®’ when displayed). By definition, a product certified Pure does not contain Pre- or Post-Consumer-Waste (PCW), so type code 31 can only occur on its own. Certification numbers may be checked at http://info.fsc.org/</xs:documentation>
+					<xs:documentation>Product carries FSC logo (Pure, 100%). &lt;ProductFormFeatureValue&gt; is the Certification number (ie either a Chain Of Custody (COC) number or a Trademark License number) printed on the book. Format: Chain of Custody number is two to five letters-COC-six digits (the digits should include leading zeros if necessary), eg ‘AB-COC-001234’ or ‘ABCDE-COC-123456’; Trademark License number is C followed by six digits, eg ‘C005678’ (this would normally be prefixed by ‘FSC®’ when displayed). The Product Form Feature Description element may carry free text indicating the grade or type of paper. By definition, a product certified Pure does not contain Pre- or Post-Consumer-Waste (PCW), so type code 31 can only occur on its own. Certification numbers may be checked at https://info.fsc.org/</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="32">
 				<xs:annotation>
 					<xs:documentation>FSC certified – mixed sources</xs:documentation>
-					<xs:documentation>Product carries FSC logo (Mixed sources, Mix). &lt;ProductFormFeatureValue&gt; is the Certification number (ie either a Chain Of Custody (COC) number or a Trademark License number) printed on the book. Format: Chain of Custody number is two to five letters-COC-six digits (the digits should include leading zeros if necessary), eg ‘AB-COC-001234’ or ‘ABCDE-COC-123456’; Trademark License number is C followed by six digits, eg ‘C005678’ (this would normally be prefixed by ‘FSC®’ when displayed). May be accompanied by a Pre- and Post-Consumer-Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature&gt; with type code 36. Certification numbers may be checked at http://info.fsc.org/</xs:documentation>
+					<xs:documentation>Product carries FSC logo (Mixed sources, Mix). &lt;ProductFormFeatureValue&gt; is the Certification number (ie either a Chain Of Custody (COC) number or a Trademark License number) printed on the book. Format: Chain of Custody number is two to five letters-COC-six digits (the digits should include leading zeros if necessary), eg ‘AB-COC-001234’ or ‘ABCDE-COC-123456’; Trademark License number is C followed by six digits, eg ‘C005678’ (this would normally be prefixed by ‘FSC®’ when displayed). The Product Form Feature Description element may carry free text indicating the grade or type of paper. May be accompanied by a Pre- and Post-Consumer-Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature&gt; with type code 36. Certification numbers may be checked at https://info.fsc.org/</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="33">
 				<xs:annotation>
 					<xs:documentation>FSC certified – recycled</xs:documentation>
-					<xs:documentation>Product carries FSC logo (Recycled). &lt;ProductFormFeatureValue&gt; is the Certification number (ie either a Chain Of Custody (COC) number or a Trademark License number) printed on the book. Format: Chain of Custody number is two to five letters-COC-six digits (the digits should include leading zeroes if necessary), eg ‘AB-COC-001234’ or ‘ABCDE-COC-123456’; Trademark License number is C followed by six digits, eg ‘C005678’ (this would normally be prefixed by ‘FSC®’ when displayed). Should be accompanied by a Pre- and Post-Consumer-Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature&gt; with type code 36. Certification numbers may be checked at http://info.fsc.org/</xs:documentation>
+					<xs:documentation>Product carries FSC logo (Recycled). &lt;ProductFormFeatureValue&gt; is the Certification number (ie either a Chain Of Custody (COC) number or a Trademark License number) printed on the book. Format: Chain of Custody number is two to five letters-COC-six digits (the digits should include leading zeroes if necessary), eg ‘AB-COC-001234’ or ‘ABCDE-COC-123456’; Trademark License number is C followed by six digits, eg ‘C005678’ (this would normally be prefixed by ‘FSC®’ when displayed). The Product Form Feature Description element may carry free text indicating the grade or type of paper. Should be accompanied by a Pre- and Post-Consumer-Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature&gt; with type code 36. Certification numbers may be checked at https://info.fsc.org/</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="34">
 				<xs:annotation>
 					<xs:documentation>PEFC certified</xs:documentation>
-					<xs:documentation>Product carries PEFC logo (certified). &lt;ProductFormFeatureValue&gt; is the Chain Of Custody (COC) number printed on the book. May be accompanied by a Post-Consumer Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature&gt; with type code 36</xs:documentation>
+					<xs:documentation>Product carries PEFC logo (certified). &lt;ProductFormFeatureValue&gt; is the Chain Of Custody (COC) number printed on the book. The Product Form Feature Description element may carry free text indicating the grade or type of paper. May be accompanied by a Post-Consumer Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature&gt; with type code 36</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="35">
 				<xs:annotation>
 					<xs:documentation>PEFC recycled</xs:documentation>
-					<xs:documentation>Product carries PEFC logo (recycled). &lt;ProductFormFeatureValue&gt; is the Chain Of Custody (COC) number printed on the book. Should be accompanied by a Post-Consumer-Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature&gt; with type code 36</xs:documentation>
+					<xs:documentation>Product carries PEFC logo (recycled). &lt;ProductFormFeatureValue&gt; is the Chain Of Custody (COC) number printed on the book. The Product Form Feature Description element may carry free text indicating the grade or type of paper. Should be accompanied by a Post-Consumer-Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature&gt; with type code 36</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="36">
@@ -15910,25 +11743,31 @@
 			<xs:enumeration value="10">
 				<xs:annotation>
 					<xs:documentation>Text (eye-readable)</xs:documentation>
-					<xs:documentation>Readable text of the main work: this value is required, together with applicable &lt;ProductForm&gt; and &lt;ProductFormDetail&gt; values, to designate an e-book or other digital product whose primary content is eye-readable text</xs:documentation>
+					<xs:documentation>Readable text of the main work: this value is required, together with applicable &lt;ProductForm&gt; and &lt;ProductFormDetail&gt; values, to designate an e-book or other digital or physical product whose primary content is eye-readable text</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="15">
 				<xs:annotation>
 					<xs:documentation>Extensive links between internal content</xs:documentation>
-					<xs:documentation>E-publication is enhanced with a significant number of actionable cross-references, hyperlinked notes and annotations, or with other links between largely textual elements (eg quiz/test questions, ‘choose your own ending’ etc)</xs:documentation>
+					<xs:documentation>E-publication contains a significant number of actionable cross-references, hyperlinked notes and annotations, or with other actionable links between largely textual elements (eg quiz/test questions, ‘choose your own ending’ etc)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="14">
 				<xs:annotation>
 					<xs:documentation>Extensive links to external content</xs:documentation>
-					<xs:documentation>E-publication is enhanced with a significant number of actionable (clickable) web links</xs:documentation>
+					<xs:documentation>E-publication contains a significant number of actionable (clickable) web links</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="16">
 				<xs:annotation>
 					<xs:documentation>Additional eye-readable text not part of main work</xs:documentation>
-					<xs:documentation>E-publication is enhanced with additional textual content such as interview, feature article, essay, bibliography, quiz/test, other background material or text that is not included in a primary or ‘unenhanced’ version</xs:documentation>
+					<xs:documentation>Publication contains additional textual content such as interview, feature article, essay, bibliography, quiz/test, other background material or text that is not included in a primary or ‘unenhanced’ version</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Additional eye-readable links to external content</xs:documentation>
+					<xs:documentation>Publication contains a significant number of web links (printed URLs, QR codes etc). For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="17">
@@ -15964,13 +11803,19 @@
 			<xs:enumeration value="20">
 				<xs:annotation>
 					<xs:documentation>Additional images / graphics not part of main work</xs:documentation>
-					<xs:documentation>E-publication is enhanced with additional images or graphical content such as supplementary photographs that are not included in a primary or ‘unenhanced’ version</xs:documentation>
+					<xs:documentation>Publication is enhanced with additional images or graphical content such as supplementary photographs that are not included in a primary or ‘unenhanced’ version</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="12">
 				<xs:annotation>
 					<xs:documentation>Maps and/or other cartographic content</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Assessment material</xs:documentation>
+					<xs:documentation>eg Questions or student exercises, problems, quizzes or tests (as an integral part of the work). For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="01">
@@ -15988,7 +11833,7 @@
 			<xs:enumeration value="13">
 				<xs:annotation>
 					<xs:documentation>Other speech content</xs:documentation>
-					<xs:documentation>eg an interview, not a ‘reading’ or ‘performance’)</xs:documentation>
+					<xs:documentation>eg an interview, speech, lecture or discussion, not a ‘reading’ or ‘performance’)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
@@ -16107,8 +11952,8 @@
 			</xs:enumeration>
 			<xs:enumeration value="34">
 				<xs:annotation>
-					<xs:documentation>Blank pages</xs:documentation>
-					<xs:documentation>Intended to be filled in by the reader</xs:documentation>
+					<xs:documentation>Blank pages or spaces</xs:documentation>
+					<xs:documentation>Entire pages or blank spaces, forms, boxes etc, intended to be filled in by the reader</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="35">
@@ -16139,6 +11984,12 @@
 				<xs:annotation>
 					<xs:documentation>Advertising – third party textual</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Scripting</xs:documentation>
+					<xs:documentation>E-publication contains microprograms written (eg) in Javascript and executed within the reading system. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -16181,19 +12032,19 @@
 			<xs:enumeration value="GA">
 				<xs:annotation>
 					<xs:documentation>General canon with Apocrypha (Catholic canon)</xs:documentation>
-					<xs:documentation>The 66 books included in the Protestant, Catholic and Orthodox canons, together with the seven portions of the Apocrypha included in the Catholic canon</xs:documentation>
+					<xs:documentation>The 66 books included in the Protestant, Catholic and Orthodox canons, together with the seven portions of the Apocrypha included in the Catholic canon. (Equivalent to OT plus NT plus AP)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GC">
 				<xs:annotation>
 					<xs:documentation>General canon with Apocryphal texts (canon unspecified)</xs:documentation>
-					<xs:documentation>The 66 books included in the Protestant, Catholic and Orthodox canons, together with Apocryphal texts, canon not specified</xs:documentation>
+					<xs:documentation>The 66 books included in the Protestant, Catholic and Orthodox canons, together with Apocryphal texts, canon not specified. (Equivalent to OT plus NT plus AQ)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GE">
 				<xs:annotation>
 					<xs:documentation>General canon</xs:documentation>
-					<xs:documentation>The 66 books included in the Protestant, Catholic and Orthodox canons, 39 from the Old Testament and 27 from the New Testament. The sequence of books may differ in different canons</xs:documentation>
+					<xs:documentation>The 66 books included in the Protestant, Catholic and Orthodox canons, 39 from the Old Testament and 27 from the New Testament. The sequence of books may differ in different canons. (Equivalent to OT plus NT)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GS">
@@ -16217,7 +12068,7 @@
 			<xs:enumeration value="NP">
 				<xs:annotation>
 					<xs:documentation>New Testament with Psalms and Proverbs</xs:documentation>
-					<xs:documentation>Includes the 27 books of the New Testament plus Psalms and Proverbs from the Old Testament</xs:documentation>
+					<xs:documentation>Includes the 27 books of the New Testament plus Psalms and Proverbs from the Old Testament. Equivalent to NT plus PP)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PE">
@@ -16985,14 +12836,14 @@
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Church season or activity</xs:documentation>
-					<xs:documentation>A church season or activity for which a religious text is intended</xs:documentation>
+					<xs:documentation>A church season or activity for which a religious text is intended. Religious text feature code must be taken from List 90</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List90">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 90">Religious text feature code</xs:documentation>
+			<xs:documentation source="ONIX Code List 90">Religious text feature</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -17065,7 +12916,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List91">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 91">Country code – ISO 3166-1</xs:documentation>
+			<xs:documentation source="ONIX Code List 91">Country – based on ISO 3166-1</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="AD">
@@ -17113,7 +12964,7 @@
 			<xs:enumeration value="AN">
 				<xs:annotation>
 					<xs:documentation>Netherlands Antilles</xs:documentation>
-					<xs:documentation>Deprecated – use BQ, CW or SX as appropriate</xs:documentation>
+					<xs:documentation>Deprecated – use BQ, CW and SX as appropriate</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="AO">
@@ -17412,8 +13263,8 @@
 			</xs:enumeration>
 			<xs:enumeration value="CZ">
 				<xs:annotation>
-					<xs:documentation>Czech Republic</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Czechia</xs:documentation>
+					<xs:documentation>Formerly Czech Republic</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="DE">
@@ -17910,7 +13761,7 @@
 			</xs:enumeration>
 			<xs:enumeration value="MD">
 				<xs:annotation>
-					<xs:documentation>Moldova, Repubic of</xs:documentation>
+					<xs:documentation>Moldova, Republic of</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
@@ -18354,8 +14205,8 @@
 			</xs:enumeration>
 			<xs:enumeration value="SZ">
 				<xs:annotation>
-					<xs:documentation>Swaziland</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Eswatini</xs:documentation>
+					<xs:documentation>Formerly known as Swaziland</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="TC">
@@ -18726,61 +14577,29 @@
 					<xs:documentation>Use only where exclusive/non-exclusive status is not known. Prefer 10 or 11 as appropriate, where possible</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List94">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 94">Default linear unit</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="cm">
+			<xs:enumeration value="13">
 				<xs:annotation>
-					<xs:documentation>Centimeters</xs:documentation>
-					<xs:documentation>Millimeters are the preferred metric unit of length</xs:documentation>
+					<xs:documentation>Exclusive distributor to retailers and end-customers</xs:documentation>
+					<xs:documentation>Intermediary as exclusive distributor to retailers and direct to consumers and/or institutional customers. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="in">
+			<xs:enumeration value="14">
 				<xs:annotation>
-					<xs:documentation>Inches (US)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Non-exclusive distributor to retailers and end-customers</xs:documentation>
+					<xs:documentation>Intermediary as non-exclusive distributor to retailers and direct to consumers and/or institutional customers. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="mm">
+			<xs:enumeration value="15">
 				<xs:annotation>
-					<xs:documentation>Millimeters</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List95">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 95">Default unit of weight</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="lb">
-				<xs:annotation>
-					<xs:documentation>Pounds (US)</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="gr">
-				<xs:annotation>
-					<xs:documentation>Grams</xs:documentation>
-					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="oz">
-				<xs:annotation>
-					<xs:documentation>Ounces (US)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Distributor to retailers and end-customers</xs:documentation>
+					<xs:documentation>Use only where exclusive/non-exclusive status is not known. Prefer codes 13 or 14 as appropriate whenever possible. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List96">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 96">Currency code – ISO 4217</xs:documentation>
+			<xs:documentation source="ONIX Code List 96">Currency code – based on ISO 4217</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="AED">
@@ -18834,7 +14653,7 @@
 			<xs:enumeration value="ATS">
 				<xs:annotation>
 					<xs:documentation>Schilling</xs:documentation>
-					<xs:documentation>Austria. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Austria. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="AUD">
@@ -18851,7 +14670,7 @@
 			</xs:enumeration>
 			<xs:enumeration value="AZN">
 				<xs:annotation>
-					<xs:documentation>Azerbaijanian Manat</xs:documentation>
+					<xs:documentation>Azerbaijan Manat</xs:documentation>
 					<xs:documentation>Azerbaijan</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
@@ -18876,7 +14695,7 @@
 			<xs:enumeration value="BEF">
 				<xs:annotation>
 					<xs:documentation>Belgian Franc</xs:documentation>
-					<xs:documentation>Belgium. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Belgium. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="BGL">
@@ -18947,8 +14766,8 @@
 			</xs:enumeration>
 			<xs:enumeration value="BYR">
 				<xs:annotation>
-					<xs:documentation>Belarussian Ruble</xs:documentation>
-					<xs:documentation>Belarus (prices normally quoted as integers). Now replaced by new Belarussian Ruble (BYN): use only for historical prices that pre-date the introduction of the new Belarussian Ruble</xs:documentation>
+					<xs:documentation>(Old) Belarussian Ruble</xs:documentation>
+					<xs:documentation>Belarus (prices normally quoted as integers). Deprecated – now replaced by new Belarussian Ruble (BYN): use only for historical prices that pre-date the introduction of the new Belarussian Ruble</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="BYN">
@@ -19032,19 +14851,19 @@
 			<xs:enumeration value="CYP">
 				<xs:annotation>
 					<xs:documentation>Cyprus Pound</xs:documentation>
-					<xs:documentation>Cyprus. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Cyprus. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CZK">
 				<xs:annotation>
 					<xs:documentation>Czech Koruna</xs:documentation>
-					<xs:documentation>Czech Republic</xs:documentation>
+					<xs:documentation>Czechia</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="DEM">
 				<xs:annotation>
 					<xs:documentation>Mark</xs:documentation>
-					<xs:documentation>Germany. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Germany. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="DJF">
@@ -19074,7 +14893,7 @@
 			<xs:enumeration value="EEK">
 				<xs:annotation>
 					<xs:documentation>Kroon</xs:documentation>
-					<xs:documentation>Estonia.Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Estonia.Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="EGP">
@@ -19092,7 +14911,7 @@
 			<xs:enumeration value="ESP">
 				<xs:annotation>
 					<xs:documentation>Peseta</xs:documentation>
-					<xs:documentation>Spain. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro (prices normally quoted as integers)</xs:documentation>
+					<xs:documentation>Spain. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro (prices normally quoted as integers)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="ETB">
@@ -19110,7 +14929,7 @@
 			<xs:enumeration value="FIM">
 				<xs:annotation>
 					<xs:documentation>Markka</xs:documentation>
-					<xs:documentation>Finland. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Finland. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="FJD">
@@ -19128,13 +14947,13 @@
 			<xs:enumeration value="FRF">
 				<xs:annotation>
 					<xs:documentation>Franc</xs:documentation>
-					<xs:documentation>France. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>France. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GBP">
 				<xs:annotation>
 					<xs:documentation>Pound Sterling</xs:documentation>
-					<xs:documentation>United Kingdom, Isle of Man, Channel Islands, South Georgia, South Sandwich Islands</xs:documentation>
+					<xs:documentation>United Kingdom, Isle of Man, Channel Islands, South Georgia, South Sandwich Islands, British Indian Ocean Territory (de jure)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GEL">
@@ -19169,14 +14988,14 @@
 			</xs:enumeration>
 			<xs:enumeration value="GNF">
 				<xs:annotation>
-					<xs:documentation>Guinea Franc</xs:documentation>
+					<xs:documentation>Guinean Franc</xs:documentation>
 					<xs:documentation>Guinea (prices normally quoted as integers)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GRD">
 				<xs:annotation>
 					<xs:documentation>Drachma</xs:documentation>
-					<xs:documentation>Greece. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Greece. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GTQ">
@@ -19236,7 +15055,7 @@
 			<xs:enumeration value="IEP">
 				<xs:annotation>
 					<xs:documentation>Punt</xs:documentation>
-					<xs:documentation>Ireland. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Ireland. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="ILS">
@@ -19272,7 +15091,7 @@
 			<xs:enumeration value="ITL">
 				<xs:annotation>
 					<xs:documentation>Lira</xs:documentation>
-					<xs:documentation>italy. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro (prices normally quoted as integers)</xs:documentation>
+					<xs:documentation>Italy. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro (prices normally quoted as integers)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="JMD">
@@ -19313,7 +15132,7 @@
 			</xs:enumeration>
 			<xs:enumeration value="KMF">
 				<xs:annotation>
-					<xs:documentation>Comoro Franc</xs:documentation>
+					<xs:documentation>Comorian Franc</xs:documentation>
 					<xs:documentation>Comoros (prices normally quoted as integers)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
@@ -19349,7 +15168,7 @@
 			</xs:enumeration>
 			<xs:enumeration value="LAK">
 				<xs:annotation>
-					<xs:documentation>Kip</xs:documentation>
+					<xs:documentation>Lao Kip</xs:documentation>
 					<xs:documentation>Lao People’s Democratic Republic (prices normally quoted as integers)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
@@ -19380,19 +15199,19 @@
 			<xs:enumeration value="LTL">
 				<xs:annotation>
 					<xs:documentation>Litus</xs:documentation>
-					<xs:documentation>Lithuania. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Lithuania. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="LUF">
 				<xs:annotation>
 					<xs:documentation>Luxembourg Franc</xs:documentation>
-					<xs:documentation>Luxembourg. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro (prices normally quoted as integers)</xs:documentation>
+					<xs:documentation>Luxembourg. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro (prices normally quoted as integers)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="LVL">
 				<xs:annotation>
 					<xs:documentation>Latvian Lats</xs:documentation>
-					<xs:documentation>Latvia. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Latvia. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="LYD">
@@ -19451,14 +15270,20 @@
 			</xs:enumeration>
 			<xs:enumeration value="MRO">
 				<xs:annotation>
+					<xs:documentation>(Old) Ouguiya</xs:documentation>
+					<xs:documentation>Mauritania (prices normally quoted with 0 or 1 decimal place – 1 khoums = UM0.2). Was interchangeable with MRU (New) Ouguiya at rate of 10:1 until June 2018. DEPRECATED, use MRU instead</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MRU">
+				<xs:annotation>
 					<xs:documentation>Ouguiya</xs:documentation>
-					<xs:documentation>Mauritania (0 or 1 – 1 khoums = UM0.2)</xs:documentation>
+					<xs:documentation>Mauritania (prices normally quoted with 0 or 1 decimal place – 1 khoums = UM0.2). Replaced MRO (old) Ouguiya at rate of 10:1 in June 2018. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="MTL">
 				<xs:annotation>
 					<xs:documentation>Maltese Lira</xs:documentation>
-					<xs:documentation>Malta. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Malta. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="MUR">
@@ -19518,7 +15343,7 @@
 			<xs:enumeration value="NLG">
 				<xs:annotation>
 					<xs:documentation>Guilder</xs:documentation>
-					<xs:documentation>Netherlands. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Netherlands. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="NOK">
@@ -19577,14 +15402,14 @@
 			</xs:enumeration>
 			<xs:enumeration value="PLN">
 				<xs:annotation>
-					<xs:documentation>Zloty</xs:documentation>
+					<xs:documentation>Złoty</xs:documentation>
 					<xs:documentation>Poland</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PTE">
 				<xs:annotation>
 					<xs:documentation>Escudo</xs:documentation>
-					<xs:documentation>Portugal. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Portugal. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PYG">
@@ -19686,13 +15511,13 @@
 			<xs:enumeration value="SIT">
 				<xs:annotation>
 					<xs:documentation>Tolar</xs:documentation>
-					<xs:documentation>Slovenia. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Slovenia. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="SKK">
 				<xs:annotation>
 					<xs:documentation>Slovak Koruna</xs:documentation>
-					<xs:documentation>Slovakia. Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
+					<xs:documentation>Slovakia. Now replaced by the Euro (EUR). Deprecated – use only for historical prices that pre-date the introduction of the Euro</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="SLL">
@@ -19721,8 +15546,14 @@
 			</xs:enumeration>
 			<xs:enumeration value="STD">
 				<xs:annotation>
+					<xs:documentation>(Old) Dobra</xs:documentation>
+					<xs:documentation>São Tome and Principe (prices normally quoted as integers). Was interchangeable with STN (New) Dobra at rate of 1000:1 until June 2018. DEPRECATED, use STN instead</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="STN">
+				<xs:annotation>
 					<xs:documentation>Dobra</xs:documentation>
-					<xs:documentation>São Tome and Principe (prices normally quoted as integers)</xs:documentation>
+					<xs:documentation>São Tome and Principe. Replaced STD (old) Dobra at rate of 1000:1 in June 2018. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="SVC">
@@ -19740,7 +15571,7 @@
 			<xs:enumeration value="SZL">
 				<xs:annotation>
 					<xs:documentation>Lilangeni</xs:documentation>
-					<xs:documentation>Swaziland</xs:documentation>
+					<xs:documentation>Eswatini (formerly known as Swaziland)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="THB">
@@ -19847,14 +15678,20 @@
 			</xs:enumeration>
 			<xs:enumeration value="VEB">
 				<xs:annotation>
-					<xs:documentation>Bolivar</xs:documentation>
+					<xs:documentation>Bolívar</xs:documentation>
 					<xs:documentation>Deprecated, replaced by VEF</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="VEF">
 				<xs:annotation>
 					<xs:documentation>Bolívar</xs:documentation>
-					<xs:documentation>Venezuela (formerly Bolívar fuerte)</xs:documentation>
+					<xs:documentation>Venezuela (formerly Bolívar fuerte). Deprecated, replaced by VES</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VES">
+				<xs:annotation>
+					<xs:documentation>Bolívar Soberano</xs:documentation>
+					<xs:documentation>Venezuela (replaced VEF from August 2018 at rate of 100,000:1). For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="VND">
@@ -19958,7 +15795,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List98">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 98">Product form feature value – binding or page edge color</xs:documentation>
+			<xs:documentation source="ONIX Code List 98">Binding or page edge color</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="BLK">
@@ -19981,7 +15818,13 @@
 			</xs:enumeration>
 			<xs:enumeration value="BUR">
 				<xs:annotation>
-					<xs:documentation>Burgundy/maroon</xs:documentation>
+					<xs:documentation>Burgundy/Maroon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CEL">
+				<xs:annotation>
+					<xs:documentation>Celadon/Pale green</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
@@ -19994,13 +15837,13 @@
 			<xs:enumeration value="FCO">
 				<xs:annotation>
 					<xs:documentation>Four-color</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Use &lt;ProductFormFeatureDescription&gt; to add brief details if required</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="FCS">
 				<xs:annotation>
 					<xs:documentation>Four-color and spot-color</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Use &lt;ProductFormFeatureDescription&gt; to add brief details if required</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="GLD">
@@ -20096,14 +15939,14 @@
 			<xs:enumeration value="ZZZ">
 				<xs:annotation>
 					<xs:documentation>Other</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Use &lt;ProductFormFeatureDescription&gt; to add brief details if required</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List99">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 99">Product form feature value – special cover material</xs:documentation>
+			<xs:documentation source="ONIX Code List 99">Special cover material</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -20278,7 +16121,7 @@
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>BIC discount group code</xs:documentation>
-					<xs:documentation>UK publisher’s or distributor’s discount group code in a format specified by BIC to ensure uniqueness</xs:documentation>
+					<xs:documentation>UK publisher’s or distributor’s discount group code in a format specified by BIC to ensure uniqueness (a five-letter prefix allocated by BIC, plus one to three alphanumeric characters – normally digits – chosen by the supplier)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
@@ -20313,43 +16156,6 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="List101">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 101">Person name identifier type</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>Proprietary</xs:documentation>
-					<xs:documentation>Note that &lt;IDTypeName&gt; is required with proprietary identifiers</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>PND</xs:documentation>
-					<xs:documentation>Personennamendatei – person name authority file used by Deutsche Nationalbibliothek and in other German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/pnd.htm (German) or http://www.d-nb.de/eng/standardisierung/normdateien/pnd.htm (English). DEPRECATED in favour of the GND</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>LCCN</xs:documentation>
-					<xs:documentation>Library of Congress control number assigned to a Library of Congress Name Authority record</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="16">
-				<xs:annotation>
-					<xs:documentation>ISNI</xs:documentation>
-					<xs:documentation>International Standard Name Identifier. See http://www.isni.org/</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="25">
-				<xs:annotation>
-					<xs:documentation>GND</xs:documentation>
-					<xs:documentation>Gemeinsame Normdatei – Joint Authority File in the German-speaking countries. See http://www.dnb.de/EN/gnd (English). Combines the PND, SWD and GKD into a single authority file, and should be used in preference</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="List102">
 		<xs:annotation>
 			<xs:documentation source="ONIX Code List 102">Sales outlet identifier type</xs:documentation>
@@ -20361,29 +16167,53 @@
 					<xs:documentation>Proprietary list of retail and other end-user sales outlet IDs. Note that &lt;IDTypeName&gt; is required with proprietary identifiers</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>BIC sales outlet ID code</xs:documentation>
-					<xs:documentation>DEPRECATED – use code 03</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>ONIX retail sales outlet ID code</xs:documentation>
 					<xs:documentation>Use with ONIX retail and other end-user sales outlet IDs from List 139</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Retail sales outlet GLN</xs:documentation>
+					<xs:documentation>13-digit GS1 global location number (formerly EAN location number)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Retail sales outlet SAN</xs:documentation>
+					<xs:documentation>7-digit Book trade Standard Address Number (US, UK etc)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List121">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 121">Text script code – ISO 15924</xs:documentation>
+			<xs:documentation source="ONIX Code List 121">Text script – based on ISO 15924</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
+			<xs:enumeration value="Adlm">
+				<xs:annotation>
+					<xs:documentation>Adlam</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="Afak">
 				<xs:annotation>
 					<xs:documentation>Afaka</xs:documentation>
 					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Aghb">
+				<xs:annotation>
+					<xs:documentation>Caucasian Albanian</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Ahom">
+				<xs:annotation>
+					<xs:documentation>Ahom, Tai Ahom</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Arab">
@@ -20392,10 +16222,16 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="Aran">
+				<xs:annotation>
+					<xs:documentation>Arabic (Nastaliq variant)</xs:documentation>
+					<xs:documentation>Typographic variant of Arabic. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="Armi">
 				<xs:annotation>
 					<xs:documentation>Imperial Aramaic</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Armn">
@@ -20407,7 +16243,7 @@
 			<xs:enumeration value="Avst">
 				<xs:annotation>
 					<xs:documentation>Avestan</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Bali">
@@ -20425,7 +16261,7 @@
 			<xs:enumeration value="Bass">
 				<xs:annotation>
 					<xs:documentation>Bassa Vah</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Batk">
@@ -20436,8 +16272,14 @@
 			</xs:enumeration>
 			<xs:enumeration value="Beng">
 				<xs:annotation>
-					<xs:documentation>Bengali</xs:documentation>
+					<xs:documentation>Bengali (Bangla)</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bhks">
+				<xs:annotation>
+					<xs:documentation>Bhaiksuki</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Blis">
@@ -20455,7 +16297,7 @@
 			<xs:enumeration value="Brah">
 				<xs:annotation>
 					<xs:documentation>Brahmi</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Brai">
@@ -20479,7 +16321,7 @@
 			<xs:enumeration value="Cakm">
 				<xs:annotation>
 					<xs:documentation>Chakma</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Cans">
@@ -20491,7 +16333,7 @@
 			<xs:enumeration value="Cari">
 				<xs:annotation>
 					<xs:documentation>Carian</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Cham">
@@ -20515,13 +16357,13 @@
 			<xs:enumeration value="Copt">
 				<xs:annotation>
 					<xs:documentation>Coptic</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Cprt">
 				<xs:annotation>
 					<xs:documentation>Cypriot</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Cyrl">
@@ -20533,13 +16375,19 @@
 			<xs:enumeration value="Cyrs">
 				<xs:annotation>
 					<xs:documentation>Cyrillic (Old Church Slavonic variant)</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic, typographic variant of Cyrillic</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Deva">
 				<xs:annotation>
 					<xs:documentation>Devanagari (Nagari)</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Dogr">
+				<xs:annotation>
+					<xs:documentation>Dogra</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Dsrt">
@@ -20551,7 +16399,7 @@
 			<xs:enumeration value="Dupl">
 				<xs:annotation>
 					<xs:documentation>Duployan shorthand, Duployan stenography</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Egyd">
@@ -20569,13 +16417,13 @@
 			<xs:enumeration value="Egyp">
 				<xs:annotation>
 					<xs:documentation>Egyptian hieroglyphs</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Elba">
 				<xs:annotation>
 					<xs:documentation>Elbasan</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Ethi">
@@ -20587,31 +16435,43 @@
 			<xs:enumeration value="Geok">
 				<xs:annotation>
 					<xs:documentation>Khutsuri (Asomtavruli and Khutsuri)</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Georgian in Unicode</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Geor">
 				<xs:annotation>
-					<xs:documentation>Georgian (Mkhedruli)</xs:documentation>
+					<xs:documentation>Georgian (Mkhedruli and Mtavruli)</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Glag">
 				<xs:annotation>
 					<xs:documentation>Glagolitic</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Gong">
+				<xs:annotation>
+					<xs:documentation>Gunjala Gondi</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Gonm">
+				<xs:annotation>
+					<xs:documentation>Masaram Gondi</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Goth">
 				<xs:annotation>
 					<xs:documentation>Gothic</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Gran">
 				<xs:annotation>
 					<xs:documentation>Grantha</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Grek">
@@ -20630,6 +16490,12 @@
 				<xs:annotation>
 					<xs:documentation>Gurmukhi</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hanb">
+				<xs:annotation>
+					<xs:documentation>Han with Bopomofo</xs:documentation>
+					<xs:documentation>See Hani, Bopo. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Hang">
@@ -20653,13 +16519,19 @@
 			<xs:enumeration value="Hans">
 				<xs:annotation>
 					<xs:documentation>Han (Simplified variant)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Subset of Hani</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Hant">
 				<xs:annotation>
 					<xs:documentation>Han (Traditional variant)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Subset of Hani</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hatr">
+				<xs:annotation>
+					<xs:documentation>Hatran</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Hebr">
@@ -20674,22 +16546,28 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="Hluw">
+				<xs:annotation>
+					<xs:documentation>Anatolian Hieroglyphs (Luwian Hieroglyphs, Hittite Hieroglyphs)</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="Hmng">
 				<xs:annotation>
 					<xs:documentation>Pahawh Hmong</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Hrkt">
 				<xs:annotation>
 					<xs:documentation>Japanese syllabaries (alias for Hiragana + Katakana)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>See Hira, Kana</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Hung">
 				<xs:annotation>
-					<xs:documentation>Old Hungarian</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Old Hungarian (Hungarian Runic)</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Inds">
@@ -20701,7 +16579,13 @@
 			<xs:enumeration value="Ital">
 				<xs:annotation>
 					<xs:documentation>Old Italic (Etruscan, Oscan, etc.)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Jamo">
+				<xs:annotation>
+					<xs:documentation>Jamo (alias for Jamo subset of Hangul)</xs:documentation>
+					<xs:documentation>Subset of Hang. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Java">
@@ -20712,8 +16596,8 @@
 			</xs:enumeration>
 			<xs:enumeration value="Jpan">
 				<xs:annotation>
-					<xs:documentation>Japanese syllabaries (alias for Han + Hiragana + Katakana)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Japanese (alias for Han + Hiragana + Katakana)</xs:documentation>
+					<xs:documentation>See Hani, Hira and Kana</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Jurc">
@@ -20737,7 +16621,7 @@
 			<xs:enumeration value="Khar">
 				<xs:annotation>
 					<xs:documentation>Kharoshthi</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Khmr">
@@ -20749,7 +16633,19 @@
 			<xs:enumeration value="Khoj">
 				<xs:annotation>
 					<xs:documentation>Khojki</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kitl">
+				<xs:annotation>
+					<xs:documentation>Khitan large script</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kits">
+				<xs:annotation>
+					<xs:documentation>Khitan small script</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Knda">
@@ -20761,7 +16657,7 @@
 			<xs:enumeration value="Kore">
 				<xs:annotation>
 					<xs:documentation>Korean (alias for Hangul + Han)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>See Hani and Hang</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Kpel">
@@ -20773,12 +16669,12 @@
 			<xs:enumeration value="Kthi">
 				<xs:annotation>
 					<xs:documentation>Kaithi</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Lana">
 				<xs:annotation>
-					<xs:documentation>Lanna, Tai Tham</xs:documentation>
+					<xs:documentation>Tai Tham (Lanna)</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
@@ -20791,19 +16687,25 @@
 			<xs:enumeration value="Latf">
 				<xs:annotation>
 					<xs:documentation>Latin (Fraktur variant)</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Typographic variant of Latin</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Latg">
 				<xs:annotation>
 					<xs:documentation>Latin (Gaelic variant)</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Typographic variant of Latin</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Latn">
 				<xs:annotation>
 					<xs:documentation>Latin</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Leke">
+				<xs:annotation>
+					<xs:documentation>Leke</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Lepc">
@@ -20821,13 +16723,13 @@
 			<xs:enumeration value="Lina">
 				<xs:annotation>
 					<xs:documentation>Linear A</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Linb">
 				<xs:annotation>
 					<xs:documentation>Linear B</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Lisu">
@@ -20845,13 +16747,25 @@
 			<xs:enumeration value="Lyci">
 				<xs:annotation>
 					<xs:documentation>Lycian</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Lydi">
 				<xs:annotation>
 					<xs:documentation>Lydian</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mahj">
+				<xs:annotation>
+					<xs:documentation>Mahajani</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Maka">
+				<xs:annotation>
+					<xs:documentation>Makasar</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Mand">
@@ -20863,7 +16777,13 @@
 			<xs:enumeration value="Mani">
 				<xs:annotation>
 					<xs:documentation>Manichaean</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Marc">
+				<xs:annotation>
+					<xs:documentation>Marchen</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Maya">
@@ -20872,22 +16792,28 @@
 					<xs:documentation>Script is not supported by Unicode</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="Medf">
+				<xs:annotation>
+					<xs:documentation>Medefaidrin (Oberi Okaime, Oberi Ɔkaimɛ)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="Mend">
 				<xs:annotation>
-					<xs:documentation>Mende</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Mende Kikakui</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Merc">
 				<xs:annotation>
 					<xs:documentation>Meroitic Cursive</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Mero">
 				<xs:annotation>
 					<xs:documentation>Meroitic Hieroglyphs</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Mlym">
@@ -20896,10 +16822,16 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="Modi">
+				<xs:annotation>
+					<xs:documentation>Modi, Moḍī</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="Mong">
 				<xs:annotation>
 					<xs:documentation>Mongolian</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Includes Clear, Manchu scripts</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Moon">
@@ -20911,13 +16843,19 @@
 			<xs:enumeration value="Mroo">
 				<xs:annotation>
 					<xs:documentation>Mro, Mru</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Mtei">
 				<xs:annotation>
 					<xs:documentation>Meitei Mayek (Meithei, Meetei)</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mult">
+				<xs:annotation>
+					<xs:documentation>Multani</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Mymr">
@@ -20929,13 +16867,19 @@
 			<xs:enumeration value="Narb">
 				<xs:annotation>
 					<xs:documentation>Old North Arabian (Ancient North Arabian)</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Nbat">
 				<xs:annotation>
 					<xs:documentation>Nabatean</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Newa">
+				<xs:annotation>
+					<xs:documentation>Newa, Newar, Newari, Nepāla lipi</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Nkgb">
@@ -20953,13 +16897,13 @@
 			<xs:enumeration value="Nshu">
 				<xs:annotation>
 					<xs:documentation>Nüshu</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Ogam">
 				<xs:annotation>
 					<xs:documentation>Ogham</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Olck">
@@ -20971,13 +16915,19 @@
 			<xs:enumeration value="Orkh">
 				<xs:annotation>
 					<xs:documentation>Old Turkic, Orkhon Runic</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Orya">
 				<xs:annotation>
-					<xs:documentation>Oriya</xs:documentation>
+					<xs:documentation>Oriya (Odia)</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Osge">
+				<xs:annotation>
+					<xs:documentation>Osage</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Osma">
@@ -20989,31 +16939,37 @@
 			<xs:enumeration value="Palm">
 				<xs:annotation>
 					<xs:documentation>Palmyrene</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Pauc">
+				<xs:annotation>
+					<xs:documentation>Pau Cin Hau</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Perm">
 				<xs:annotation>
 					<xs:documentation>Old Permic</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Phag">
 				<xs:annotation>
 					<xs:documentation>Phags-pa</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Phli">
 				<xs:annotation>
 					<xs:documentation>Inscriptional Pahlavi</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Phlp">
 				<xs:annotation>
 					<xs:documentation>Psalter Pahlavi</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Phlv">
@@ -21025,19 +16981,25 @@
 			<xs:enumeration value="Phnx">
 				<xs:annotation>
 					<xs:documentation>Phoenician</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Plrd">
 				<xs:annotation>
 					<xs:documentation>Miao (Pollard)</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Piqd">
+				<xs:annotation>
+					<xs:documentation>Klingon (KLI plqaD)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Prti">
 				<xs:annotation>
 					<xs:documentation>Inscriptional Parthian</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Qaaa">
@@ -21067,7 +17029,7 @@
 			<xs:enumeration value="Runr">
 				<xs:annotation>
 					<xs:documentation>Runic</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Samr">
@@ -21085,7 +17047,7 @@
 			<xs:enumeration value="Sarb">
 				<xs:annotation>
 					<xs:documentation>Old South Arabian</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Saur">
@@ -21097,7 +17059,7 @@
 			<xs:enumeration value="Sgnw">
 				<xs:annotation>
 					<xs:documentation>SignWriting</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Shaw">
@@ -21109,13 +17071,19 @@
 			<xs:enumeration value="Shrd">
 				<xs:annotation>
 					<xs:documentation>Sharada, Śāradā</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sidd">
+				<xs:annotation>
+					<xs:documentation>Siddham, Siddhaṃ, Siddhamātṛkā</xs:documentation>
+					<xs:documentation>Ancient/historic script. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Sind">
 				<xs:annotation>
 					<xs:documentation>Khudawadi, Sindhi</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Sinh">
@@ -21127,7 +17095,13 @@
 			<xs:enumeration value="Sora">
 				<xs:annotation>
 					<xs:documentation>Sora Sompeng</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Soyo">
+				<xs:annotation>
+					<xs:documentation>Soyombo</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Sund">
@@ -21151,19 +17125,19 @@
 			<xs:enumeration value="Syre">
 				<xs:annotation>
 					<xs:documentation>Syriac (Estrangelo variant)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Typographic variant of Syriac</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Syrj">
 				<xs:annotation>
 					<xs:documentation>Syriac (Western variant)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Typographic variant of Syriac</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Syrn">
 				<xs:annotation>
 					<xs:documentation>Syriac (Eastern variant)</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Typographic variant of Syriac</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Tagb">
@@ -21175,7 +17149,7 @@
 			<xs:enumeration value="Takr">
 				<xs:annotation>
 					<xs:documentation>Takri, Ṭākrī, Ṭāṅkrī</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Tale">
@@ -21199,7 +17173,7 @@
 			<xs:enumeration value="Tang">
 				<xs:annotation>
 					<xs:documentation>Tangut</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Tavt">
@@ -21252,14 +17226,14 @@
 			</xs:enumeration>
 			<xs:enumeration value="Tirh">
 				<xs:annotation>
-					<xs:documentation>Tiruta</xs:documentation>
+					<xs:documentation>Tirhuta</xs:documentation>
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Ugar">
 				<xs:annotation>
 					<xs:documentation>Ugaritic</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Vaii">
@@ -21277,7 +17251,7 @@
 			<xs:enumeration value="Wara">
 				<xs:annotation>
 					<xs:documentation>Warang Citi (Varang Kshiti)</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Wole">
@@ -21289,19 +17263,25 @@
 			<xs:enumeration value="Xpeo">
 				<xs:annotation>
 					<xs:documentation>Old Persian</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Xsux">
 				<xs:annotation>
 					<xs:documentation>Cuneiform, Sumero-Akkadian</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Ancient/historic script</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Yiii">
 				<xs:annotation>
 					<xs:documentation>Yi</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zanb">
+				<xs:annotation>
+					<xs:documentation>Zanabazar Square (Zanabazarin Dörböljin Useg, Xewtee Dörböljin Bicig, Horizontal Square Script)</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Zinh">
@@ -21313,19 +17293,25 @@
 			<xs:enumeration value="Zmth">
 				<xs:annotation>
 					<xs:documentation>Mathematical notation</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Not a script in Unicode</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zsye">
+				<xs:annotation>
+					<xs:documentation>Symbols (Emoji variant)</xs:documentation>
+					<xs:documentation>Not a script in Unicode. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Zsym">
 				<xs:annotation>
 					<xs:documentation>Symbols</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Not a script in Unicode</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Zxxx">
 				<xs:annotation>
 					<xs:documentation>Code for unwritten documents</xs:documentation>
-					<xs:documentation>Script is not supported by Unicode</xs:documentation>
+					<xs:documentation>Not a script in Unicode</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="Zyyy">
@@ -21338,49 +17324,6 @@
 				<xs:annotation>
 					<xs:documentation>Code for uncoded script</xs:documentation>
 					<xs:documentation/>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List138">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 138">Transliteration scheme code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="SFS4900">
-				<xs:annotation>
-					<xs:documentation>Finnish standard SFS 4900</xs:documentation>
-					<xs:documentation>Transliteration of Cyrillic characters – Slavic languages</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="SFS5807">
-				<xs:annotation>
-					<xs:documentation>Finnish standard SFS 5807</xs:documentation>
-					<xs:documentation>Transliteration and transcription of Greek characters</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="SFS5755">
-				<xs:annotation>
-					<xs:documentation>Finnish standard SFS 5755</xs:documentation>
-					<xs:documentation>Transliteration of Arabic characters</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="SFS3602">
-				<xs:annotation>
-					<xs:documentation>Finnish standard SFS 5824</xs:documentation>
-					<xs:documentation>Transliteration of Hebrew characters</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ISO3602">
-				<xs:annotation>
-					<xs:documentation>ISO 3602</xs:documentation>
-					<xs:documentation>Documentation – Romanization of Japanese (kana script)</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="ISO7098">
-				<xs:annotation>
-					<xs:documentation>ISO 7098</xs:documentation>
-					<xs:documentation>Information and documentation – Romanization of Chinese</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -21486,6 +17429,12 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="BDZ">
+				<xs:annotation>
+					<xs:documentation>BDBuzz</xs:documentation>
+					<xs:documentation>www.bdbuzz.net, for use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="BBB">
 				<xs:annotation>
 					<xs:documentation>Bed Bath and Beyond</xs:documentation>
@@ -21538,6 +17487,12 @@
 				<xs:annotation>
 					<xs:documentation>Book Club Associates</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BLD">
+				<xs:annotation>
+					<xs:documentation>Bolinda</xs:documentation>
+					<xs:documentation>https://www.bolinda.com, for use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="BSH">
@@ -21693,7 +17648,7 @@
 			<xs:enumeration value="EBC">
 				<xs:annotation>
 					<xs:documentation>Ebooks Corp</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>www.ebooks.com</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="ECH">
@@ -21828,6 +17783,12 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="IBS">
+				<xs:annotation>
+					<xs:documentation>Internet Bookshop Italia</xs:documentation>
+					<xs:documentation>www.ibs.it, for use in ONIX 3.0 only</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="IZN">
 				<xs:annotation>
 					<xs:documentation>Izneo</xs:documentation>
@@ -21934,6 +17895,12 @@
 				<xs:annotation>
 					<xs:documentation>Microcenter</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MSF">
+				<xs:annotation>
+					<xs:documentation>Microsoft</xs:documentation>
+					<xs:documentation>For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="MOF">
@@ -22104,6 +18071,12 @@
 					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="SEQ">
+				<xs:annotation>
+					<xs:documentation>Sequencity</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="SBT">
 				<xs:annotation>
 					<xs:documentation>Shanghai Book Traders</xs:documentation>
@@ -22246,55 +18219,6 @@
 				<xs:annotation>
 					<xs:documentation>Other</xs:documentation>
 					<xs:documentation>Include retailer name in &lt;SalesOutletName&gt;</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="List140">
-		<xs:annotation>
-			<xs:documentation source="ONIX Code List 140">US CPSIA choking hazard warning code</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="01">
-				<xs:annotation>
-					<xs:documentation>WARNING: CHOKING HAZARD – Small parts | Not for children under 3 yrs.</xs:documentation>
-					<xs:documentation>List withdrawn – use List 143</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="02">
-				<xs:annotation>
-					<xs:documentation>WARNING: CHOKING HAZARD – This toy is a small ball | Not for children under 3 yrs.</xs:documentation>
-					<xs:documentation>List withdrawn – use List 143</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="03">
-				<xs:annotation>
-					<xs:documentation>WARNING: CHOKING HAZARD – Toy contains a small ball | Not for children under 3 yrs.</xs:documentation>
-					<xs:documentation>List withdrawn – use List 143</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="04">
-				<xs:annotation>
-					<xs:documentation>WARNING: CHOKING HAZARD – Children under 8 yrs. can choke or suffocate on uninflated or broken balloons. Adult supervision required | Keep uninflated balloons from children. Discard broken balloons at once.</xs:documentation>
-					<xs:documentation>List withdrawn – use List 143</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="05">
-				<xs:annotation>
-					<xs:documentation>WARNING: CHOKING HAZARD – This toy is a marble | Not for children under 3 yrs.</xs:documentation>
-					<xs:documentation>List withdrawn – use List 143</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="06">
-				<xs:annotation>
-					<xs:documentation>WARNING: CHOKING HAZARD – Toy contains a marble | Not for children under 3 yrs.</xs:documentation>
-					<xs:documentation>List withdrawn – use List 143</xs:documentation>
-				</xs:annotation>
-			</xs:enumeration>
-			<xs:enumeration value="07">
-				<xs:annotation>
-					<xs:documentation>No choking hazard warning necessary</xs:documentation>
-					<xs:documentation>List withdrawn – use List 143</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -22447,7 +18371,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List143">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 143">US CPSIA hazard warning code</xs:documentation>
+			<xs:documentation source="ONIX Code List 143">US CPSIA hazard warning type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -22532,7 +18456,7 @@
 			<xs:enumeration value="04">
 				<xs:annotation>
 					<xs:documentation>Apple DRM</xs:documentation>
-					<xs:documentation>Has 'FairPlay’ DRM protection applied via Apple proprietary online store</xs:documentation>
+					<xs:documentation>Has FairPlay DRM protection applied via Apple proprietary online store</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
@@ -22544,7 +18468,7 @@
 			<xs:enumeration value="06">
 				<xs:annotation>
 					<xs:documentation>Readium LCP DRM</xs:documentation>
-					<xs:documentation>Has ‘Licensed Content Protection' DRM applied by a Readium License Server</xs:documentation>
+					<xs:documentation>Has Licensed Content Protection DRM applied by a Readium License Server</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="07">
@@ -22599,13 +18523,25 @@
 			<xs:enumeration value="07">
 				<xs:annotation>
 					<xs:documentation>Time-limited license</xs:documentation>
-					<xs:documentation>E-publication license is time limited. Use with 02 from List 146 and a number of days in &lt;EpubUsageLimit&gt;. The purchased copy becomes unusable when the license expires</xs:documentation>
+					<xs:documentation>E-publication license is time limited. Use with 02 from List 146 and a time period in days, weeks or months in &lt;EpubUsageLimit&gt;. The purchased copy becomes unusable when the license expires</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Loan renewal</xs:documentation>
-					<xs:documentation>Maximum number of consecutive loans (eg from a library) to a single device owner or account holder. Note that a limit of 1 indicates that a loan cannot be renewed</xs:documentation>
+					<xs:documentation>Maximum number of consecutive loans or loan extensions (eg from a library) to a single device owner or account holder. Note that a limit of 1 indicates that a loan cannot be renewed or extended</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Multi-user license</xs:documentation>
+					<xs:documentation>E-publication license is multi-user. Maximum number of concurrent users licensed to use the product should be given in &lt;EpubUsageLimit&gt;</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Preview on premises</xs:documentation>
+					<xs:documentation>Preview locally before purchase. Allows a retail customer, account holder or patron to view a proportion of the book (or the whole book, if no proportion is specified) before purchase, but ONLY while located physically in the retailer’s store (eg while logged on to the store or library wifi). Also applies to patrons making use of ‘acquisition on demand’ models in libraries</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -22624,7 +18560,7 @@
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>Permitted subject to limit</xs:documentation>
-					<xs:documentation>Limit should be specified in &lt;EpubUsageLimit&gt;</xs:documentation>
+					<xs:documentation>Limit should be specified in &lt;EpubUsageLimit&gt; or &lt;PriceConstraintLimit&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
@@ -22682,6 +18618,24 @@
 					<xs:documentation>Maximum number of concurrent users. NB where the number of concurrent users is specifically not limited, set the number of concurrent users to zero</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Users</xs:documentation>
+					<xs:documentation>Maximum number of licenced individual users, independent of concurrency of use</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Concurrent classes</xs:documentation>
+					<xs:documentation>A ‘class’ is a group of learners attending a specific course or lesson and generally taught as a group</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Classes</xs:documentation>
+					<xs:documentation>Maximum number of classes of learners, independent of concurrency of use</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Percentage per time period</xs:documentation>
@@ -22691,7 +18645,7 @@
 			<xs:enumeration value="09">
 				<xs:annotation>
 					<xs:documentation>Days</xs:documentation>
-					<xs:documentation>Maximum time period in days</xs:documentation>
+					<xs:documentation>Maximum time period in days (beginning from product purchase or activation)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="13">
@@ -22706,15 +18660,63 @@
 					<xs:documentation>Maximum time period in months</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Hours minutes and seconds</xs:documentation>
+					<xs:documentation>Maximum about of time in hours, minutes and seconds allowed in a permitted extract for a specified usage, in the format HHHMMSS (7 digits, with leading zeros if necessary)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Days (fixed start)</xs:documentation>
+					<xs:documentation>Maximum time period in days (beginning from the product publication date). In effect, this defines a fixed end date for the license independent of the purchase or activation date</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Weeks (fixed start)</xs:documentation>
+					<xs:documentation>Maximum time period in weeks</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Months (fixed start)</xs:documentation>
+					<xs:documentation>Maximum time period in months</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="10">
 				<xs:annotation>
 					<xs:documentation>Times</xs:documentation>
-					<xs:documentation>Maximum number of times a specified usage event may occur</xs:documentation>
+					<xs:documentation>Maximum number of times a specified usage event may occur (in the lifetime of the product)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Times per day</xs:documentation>
+					<xs:documentation>Maximum frequency a specified usage event may occur (per day)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Times per month</xs:documentation>
+					<xs:documentation>Maximum frequency a specified usage event may occur (per month)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Times per year</xs:documentation>
+					<xs:documentation>Maximum frequency a specified usage event may occur (per year)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="21">
 				<xs:annotation>
 					<xs:documentation>Dots per inch</xs:documentation>
+					<xs:documentation>Maximum resolution of printed or copy/pasted extracts</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Dots per cm</xs:documentation>
 					<xs:documentation>Maximum resolution of printed or copy/pasted extracts</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
@@ -22728,6 +18730,18 @@
 				<xs:annotation>
 					<xs:documentation>Allowed usage end page</xs:documentation>
 					<xs:documentation>Page number at which allowed usage ends. &lt;Quantity&gt; should contain an absolute page number, counting the cover as page 1. (This type of page numbering should not be used where the e-publication has no fixed pagination). Use with Start page to specify pages allowed in a preview</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Allowed usage start time</xs:documentation>
+					<xs:documentation>Time at which allowed usage begins. &lt;Quantity&gt; should contain an absolute time, counting from the beginning of an audio or video product, in the format HHHMMSS or HHHMMSScc. Use with Time, Percentage of content, or End time to specify time-based extract allowed in Preview</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Allowed usage end time</xs:documentation>
+					<xs:documentation>Time at which allowed usage ends. &lt;Quantity&gt; should contain an absolute time, counting from the beginning of an audio or video product, in the format HHHMMSS or HHHMMSScc. Use with Start time to specify time-based extract allowed in Preview</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -22789,7 +18803,7 @@
 			<xs:enumeration value="04">
 				<xs:annotation>
 					<xs:documentation>Content item</xs:documentation>
-					<xs:documentation>The title element refers to a content item within a product, eg a work included in a combined or ‘omnibus’ edition, or a chapter in a book</xs:documentation>
+					<xs:documentation>The title element refers to a content item within a product, eg a work included in a combined or ‘omnibus’ edition, or a chapter in a book. Generally used only for titles within &lt;ContentItem&gt; (Block 3)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
@@ -22832,7 +18846,7 @@
 			<xs:enumeration value="AC">
 				<xs:annotation>
 					<xs:documentation>CD-Audio</xs:documentation>
-					<xs:documentation>Audio compact disc, in any recording format: use for ‘red book’ (conventional audio CD) and SACD, and use coding in Product Form Detail to specify the format, if required</xs:documentation>
+					<xs:documentation>Audio compact disc: use for ‘Red book’ discs (conventional audio CD) and SACD, and use coding in &lt;ProductFormDetail&gt; to specify the format, if required</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="AD">
@@ -22844,7 +18858,7 @@
 			<xs:enumeration value="AE">
 				<xs:annotation>
 					<xs:documentation>Audio disc</xs:documentation>
-					<xs:documentation>Audio disc (excluding CD-Audio)</xs:documentation>
+					<xs:documentation>Audio disc (excluding CD-Audio): use for ‘Yellow book’ (CD-Rom-style) discs, including for example mp3 CDs, and use coding in &lt;ProductFormDetail&gt; to specify the format of the data on the disc</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="AF">
@@ -22862,7 +18876,7 @@
 			<xs:enumeration value="AH">
 				<xs:annotation>
 					<xs:documentation>CD-Extra</xs:documentation>
-					<xs:documentation>Audio compact disc with part CD-ROM content, also termed CD-Plus or Enhanced-CD: use for ‘blue book’ and ‘yellow/red book’ two-session discs</xs:documentation>
+					<xs:documentation>Audio compact disc with part CD-ROM content, also termed CD-Plus or Enhanced-CD: use for ‘Blue book’ and ‘Yellow/Red book’ two-session discs</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="AI">
@@ -22874,13 +18888,13 @@
 			<xs:enumeration value="AJ">
 				<xs:annotation>
 					<xs:documentation>Downloadable audio file</xs:documentation>
-					<xs:documentation>Audio recording downloadable online</xs:documentation>
+					<xs:documentation>Digital audio recording downloadable to the purchaser’s own device(s)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="AK">
 				<xs:annotation>
 					<xs:documentation>Pre-recorded digital audio player</xs:documentation>
-					<xs:documentation>For example, Playaway audiobook and player: use coding in Product Form Detail to specify the recording format, if required</xs:documentation>
+					<xs:documentation>For example, Playaway audiobook and player: use coding in &lt;ProductFormDetail&gt; to specify the recording format, if required</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="AL">
@@ -22889,10 +18903,28 @@
 					<xs:documentation>For example, Audiofy audiobook chip</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="AM">
+				<xs:annotation>
+					<xs:documentation>LP</xs:documentation>
+					<xs:documentation>Vinyl disc (analogue).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AN">
+				<xs:annotation>
+					<xs:documentation>Downloadable and online audio file</xs:documentation>
+					<xs:documentation>Digital audio recording available both by download to the purchaser’s own device(s) and by online (eg streamed) access</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AO">
+				<xs:annotation>
+					<xs:documentation>Online audio file</xs:documentation>
+					<xs:documentation>Digital audio recording available online (eg streamed), not downloadable to the purchaser’s own device(s)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="AZ">
 				<xs:annotation>
 					<xs:documentation>Other audio format</xs:documentation>
-					<xs:documentation>Other audio format not specified by AB to AK</xs:documentation>
+					<xs:documentation>Other audio format not specified by AB to AM</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="BA">
@@ -22928,13 +18960,13 @@
 			<xs:enumeration value="BF">
 				<xs:annotation>
 					<xs:documentation>Pamphlet</xs:documentation>
-					<xs:documentation>Pamphlet or brochure, stapled; German ‘geheftet’. Includes low-extent wire-stitched books bound without a distinct spine (eg many comic books)</xs:documentation>
+					<xs:documentation>Pamphlet, stapled; use for German ‘geheftet’. Includes low-extent wire-stitched books bound without a distinct spine (eg many comic books)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="BG">
 				<xs:annotation>
 					<xs:documentation>Leather / fine binding</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Use &lt;ProductFormDetail&gt; to provide additional description</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="BH">
@@ -22982,7 +19014,7 @@
 			<xs:enumeration value="BO">
 				<xs:annotation>
 					<xs:documentation>Fold-out book or chart</xs:documentation>
-					<xs:documentation>Concertina-folded book or chart, designed to fold to pocket or regular page size: use for German ‘Leporello’</xs:documentation>
+					<xs:documentation>Concertina-folded booklet or chart, designed to fold to pocket or regular page size, and usually bound within distinct board or card covers: use for German ‘Leporello’</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="BP">
@@ -22994,7 +19026,7 @@
 			<xs:enumeration value="BZ">
 				<xs:annotation>
 					<xs:documentation>Other book format</xs:documentation>
-					<xs:documentation>Other book format or binding not specified by BB to BO</xs:documentation>
+					<xs:documentation>Other book format or binding not specified by BB to BP</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CA">
@@ -23018,7 +19050,7 @@
 			<xs:enumeration value="CD">
 				<xs:annotation>
 					<xs:documentation>Sheet map, rolled</xs:documentation>
-					<xs:documentation>See Code List 80 for ‘rolled in tube’</xs:documentation>
+					<xs:documentation>See &lt;ProductPackaging&gt; and Codelist 80 for ‘rolled in tube’</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="CE">
@@ -23048,7 +19080,7 @@
 			<xs:enumeration value="DC">
 				<xs:annotation>
 					<xs:documentation>CD-I</xs:documentation>
-					<xs:documentation>CD interactive: use for ‘green book’ discs</xs:documentation>
+					<xs:documentation>CD interactive: use for ‘Green book’ discs</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="DE">
@@ -23150,7 +19182,7 @@
 			<xs:enumeration value="FE">
 				<xs:annotation>
 					<xs:documentation>Filmstrip</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Photographic transparencies, unmounted but cut into short multi-frame strips</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="FF">
@@ -23180,7 +19212,7 @@
 			<xs:enumeration value="LC">
 				<xs:annotation>
 					<xs:documentation>Digital product license code</xs:documentation>
-					<xs:documentation>Digital product license delivered by email or other electronic distribution, typically providing a code enabling the purchaser to upgrade or extend the license supplied with the associated product</xs:documentation>
+					<xs:documentation>Digital product license delivered by email or other electronic distribution, typically providing a code enabling the purchaser to activate, upgrade or extend the license supplied with the associated product</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="MA">
@@ -23216,7 +19248,7 @@
 			<xs:enumeration value="PB">
 				<xs:annotation>
 					<xs:documentation>Address book</xs:documentation>
-					<xs:documentation>May use product form detail codes P201 to P204 to specify binding</xs:documentation>
+					<xs:documentation>May use &lt;ProductFormDetail&gt; codes P201 to P204 to specify binding</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PC">
@@ -23240,7 +19272,7 @@
 			<xs:enumeration value="PF">
 				<xs:annotation>
 					<xs:documentation>Diary</xs:documentation>
-					<xs:documentation>May use product form detail codes P201 to P204 to specify binding</xs:documentation>
+					<xs:documentation>May use &lt;ProductFormDetail&gt; codes P201 to P204 to specify binding</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PG">
@@ -23276,13 +19308,13 @@
 			<xs:enumeration value="PL">
 				<xs:annotation>
 					<xs:documentation>Record book</xs:documentation>
-					<xs:documentation>Record book (eg ‘birthday book’, ‘baby book’): binding unspecified; may use product form detail codes P201 to P204 to specify binding</xs:documentation>
+					<xs:documentation>Record book (eg ‘birthday book’, ‘baby book’): binding unspecified; may use &lt;ProductFormDetail&gt; codes P201 to P204 to specify binding</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PM">
 				<xs:annotation>
 					<xs:documentation>Wallet or folder</xs:documentation>
-					<xs:documentation>Wallet or folder (containing loose sheets etc): it is preferable to code the contents and treat ‘wallet’ as packaging (List 80), but if this is not possible the product as a whole may be coded as a ‘wallet’</xs:documentation>
+					<xs:documentation>Wallet or folder (containing loose sheets etc): it is preferable to code the contents and treat ‘wallet’ as packaging in &lt;ProductPackaging&gt; with Codelist 80, but if this is not possible the product as a whole may be coded as a ‘wallet’</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PN">
@@ -23312,19 +19344,25 @@
 			<xs:enumeration value="PR">
 				<xs:annotation>
 					<xs:documentation>Notebook / blank book</xs:documentation>
-					<xs:documentation>A book with all pages blank for the buyer’s own use; may use product form detail codes P201 to P204 to specify binding</xs:documentation>
+					<xs:documentation>A book with all pages blank for the buyer’s own use; may use &lt;ProductFormDetail&gt; codes P201 to P204 to specify binding</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PS">
 				<xs:annotation>
 					<xs:documentation>Organizer</xs:documentation>
-					<xs:documentation>May use product form detail codes P201 to P204 to specify binding</xs:documentation>
+					<xs:documentation>May use &lt;ProductFormDetail&gt; codes P201 to P204 to specify binding</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PT">
 				<xs:annotation>
 					<xs:documentation>Bookmark</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PU">
+				<xs:annotation>
+					<xs:documentation>Leaflet</xs:documentation>
+					<xs:documentation>Folded but unbound</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="PZ">
@@ -23335,38 +19373,38 @@
 			</xs:enumeration>
 			<xs:enumeration value="SA">
 				<xs:annotation>
-					<xs:documentation>Multiple-item retail product</xs:documentation>
-					<xs:documentation>Presentation unspecified: format of product items must be given in &lt;ProductPart&gt;</xs:documentation>
+					<xs:documentation>Multiple-component retail product</xs:documentation>
+					<xs:documentation>Presentation unspecified: format of product components must be given in &lt;ProductPart&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="SB">
 				<xs:annotation>
-					<xs:documentation>Multiple-item retail product, boxed</xs:documentation>
-					<xs:documentation>Format of product items must be given in &lt;ProductPart&gt;</xs:documentation>
+					<xs:documentation>Multiple-component retail product, boxed</xs:documentation>
+					<xs:documentation>Format of product components must be given in &lt;ProductPart&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="SC">
 				<xs:annotation>
-					<xs:documentation>Multiple-item retail product, slip-cased</xs:documentation>
-					<xs:documentation>Format of product items must be given in &lt;ProductPart&gt;</xs:documentation>
+					<xs:documentation>Multiple-component retail product, slip-cased</xs:documentation>
+					<xs:documentation>Format of product components must be given in &lt;ProductPart&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="SD">
 				<xs:annotation>
-					<xs:documentation>Multiple-item retail product, shrinkwrapped</xs:documentation>
-					<xs:documentation>Format of product items must be given in &lt;ProductPart&gt;. Use code XL for a shrink-wrapped pack for trade supply, where the retail items it contains are intended for sale individually</xs:documentation>
+					<xs:documentation>Multiple-component retail product, shrink-wrapped</xs:documentation>
+					<xs:documentation>Format of product components must be given in &lt;ProductPart&gt;. Use code XL for a shrink-wrapped pack for trade supply, where the retail items it contains are intended for sale individually</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="SE">
 				<xs:annotation>
-					<xs:documentation>Multiple-item retail product, loose</xs:documentation>
-					<xs:documentation>Format of product items must be given in &lt;ProductPart&gt;</xs:documentation>
+					<xs:documentation>Multiple-component retail product, loose</xs:documentation>
+					<xs:documentation>Format of product components must be given in &lt;ProductPart&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="SF">
 				<xs:annotation>
-					<xs:documentation>Multiple-item retail product, part(s) enclosed</xs:documentation>
-					<xs:documentation>Multiple item product where subsidiary product part(s) is/are supplied as enclosures to the primary part, eg a book with a CD packaged in a sleeve glued within the back cover. Format of product items must be given in &lt;ProductPart&gt;</xs:documentation>
+					<xs:documentation>Multiple-component retail product, part(s) enclosed</xs:documentation>
+					<xs:documentation>Multiple component product where subsidiary product part(s) is/are supplied as enclosures to the primary part, eg a book with a CD packaged in a sleeve glued within the back cover. Format of product components must be given in &lt;ProductPart&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="VA">
@@ -23384,19 +19422,19 @@
 			<xs:enumeration value="VI">
 				<xs:annotation>
 					<xs:documentation>DVD video</xs:documentation>
-					<xs:documentation>DVD video: specify TV standard in List 175</xs:documentation>
+					<xs:documentation>DVD video: specify TV standard in &lt;ProductFormDetail&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="VJ">
 				<xs:annotation>
 					<xs:documentation>VHS video</xs:documentation>
-					<xs:documentation>VHS videotape: specify TV standard in List 175</xs:documentation>
+					<xs:documentation>VHS videotape: specify TV standard in &lt;ProductFormDetail&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="VK">
 				<xs:annotation>
 					<xs:documentation>Betamax video</xs:documentation>
-					<xs:documentation>Betamax videotape: specify TV standard in List 175</xs:documentation>
+					<xs:documentation>Betamax videotape: specify TV standard in &lt;ProductFormDetail&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="VL">
@@ -23438,7 +19476,7 @@
 			<xs:enumeration value="VZ">
 				<xs:annotation>
 					<xs:documentation>Other video format</xs:documentation>
-					<xs:documentation>Other video format not specified by VB to VP</xs:documentation>
+					<xs:documentation>Other video format not specified by VB to VQ</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="XA">
@@ -23456,7 +19494,7 @@
 			<xs:enumeration value="XC">
 				<xs:annotation>
 					<xs:documentation>Dumpbin – filled</xs:documentation>
-					<xs:documentation>Dumpbin with contents. ISBN (where applicable) and format of contained items must be given in Product Part</xs:documentation>
+					<xs:documentation>Dumpbin with contents. ISBN (where applicable) and format of contained items must be given in &lt;ProductPart&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="XD">
@@ -23468,7 +19506,7 @@
 			<xs:enumeration value="XE">
 				<xs:annotation>
 					<xs:documentation>Counterpack – filled</xs:documentation>
-					<xs:documentation>Counterpack with contents. ISBN (where applicable) and format of contained items must be given in Product Part</xs:documentation>
+					<xs:documentation>Counterpack with contents. ISBN (where applicable) and format of contained items must be given in &lt;ProductPart&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="XF">
@@ -23510,13 +19548,13 @@
 			<xs:enumeration value="XL">
 				<xs:annotation>
 					<xs:documentation>Shrink-wrapped pack</xs:documentation>
-					<xs:documentation>A quantity pack with its own product code, for trade supply only: the retail items it contains are intended for sale individually. ISBN (where applicable) and format of contained items must be given in Product Part. For products or product bundles supplied individually shrink-wrapped for retail sale, use code SD</xs:documentation>
+					<xs:documentation>A quantity pack with its own product code, usually for trade supply only: the retail items it contains are intended for sale individually. ISBN (where applicable) and format of contained items must be given in &lt;ProductPart&gt;. For products or product bundles supplied individually shrink-wrapped for retail sale, use code SD</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="XM">
 				<xs:annotation>
 					<xs:documentation>Boxed pack</xs:documentation>
-					<xs:documentation>A quantity pack with its own product code, for trade supply only: the retail items it contains are intended for sale individually. ISBN (where applicable) and format of contained items must be given in Product Part. For products or product bundles boxed individually for retail sale, use code SB</xs:documentation>
+					<xs:documentation>A quantity pack with its own product code, usually for trade supply only: the retail items it contains are intended for sale individually. ISBN (where applicable) and format of contained items must be given in &lt;ProductPart&gt;. For products or product bundles boxed individually for retail sale, use code SB</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="XZ">
@@ -23552,7 +19590,7 @@
 			<xs:enumeration value="ZE">
 				<xs:annotation>
 					<xs:documentation>Game</xs:documentation>
-					<xs:documentation>Board game, or other game (except computer game: see DE)</xs:documentation>
+					<xs:documentation>Board game, or other game (except computer game: see DE and other D* codes)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="ZF">
@@ -23588,19 +19626,31 @@
 			<xs:enumeration value="ZK">
 				<xs:annotation>
 					<xs:documentation>Mug</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>For example, branded, promotional or tie-in drinking mug, cup etc</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="ZL">
 				<xs:annotation>
 					<xs:documentation>Tote bag</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>For example, branded, promotional or tie-in bag</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZM">
+				<xs:annotation>
+					<xs:documentation>Tableware</xs:documentation>
+					<xs:documentation>For example, branded, promotional or tie-in plates, bowls etc (note for mugs and cups, use code ZK)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZN">
+				<xs:annotation>
+					<xs:documentation>Umbrella</xs:documentation>
+					<xs:documentation>For example, branded, promotional or tie-in umbrella</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="ZY">
 				<xs:annotation>
 					<xs:documentation>Other apparel</xs:documentation>
-					<xs:documentation>Other apparel items not specified by ZB to ZJ, including promotional or branded scarves, caps, aprons etc</xs:documentation>
+					<xs:documentation>Other apparel items not specified by ZB to ZJ, including branded, promotional or tie-in scarves, caps, aprons etc</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="ZZ">
@@ -23711,13 +19761,13 @@
 			<xs:enumeration value="04">
 				<xs:annotation>
 					<xs:documentation>Table of contents</xs:documentation>
-					<xs:documentation>Used for a table of contents sent as a single text field, which may or may not carry structure expressed as XHTML</xs:documentation>
+					<xs:documentation>Used for a table of contents sent as a single text field, which may or may not carry structure expressed using XHTML</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
 				<xs:annotation>
 					<xs:documentation>Flap / cover copy</xs:documentation>
-					<xs:documentation>Descriptive blurb taken from the back cover and/or flaps</xs:documentation>
+					<xs:documentation>Primary descriptive blurb taken from the back cover and/or flaps. See also code 27</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
@@ -23771,7 +19821,7 @@
 			<xs:enumeration value="14">
 				<xs:annotation>
 					<xs:documentation>Excerpt</xs:documentation>
-					<xs:documentation>A short excerpt from the work</xs:documentation>
+					<xs:documentation>A short excerpt from the main text of the work</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="15">
@@ -23826,6 +19876,42 @@
 				<xs:annotation>
 					<xs:documentation>JBPA description</xs:documentation>
 					<xs:documentation>Short description in format specified by Japanese Book Publishers Association</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>schema.org snippet</xs:documentation>
+					<xs:documentation>JSON-LD snippet suitable for use within an HTML &lt;script type="application/ld+json"&gt; tag, containing structured metadata suitable for use with schema.org</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Errata</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Introduction</xs:documentation>
+					<xs:documentation>Introduction, preface or the text of other preliminary material, sent as a single text field, which may be structured using XHTML</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Secondary flap / cover copy</xs:documentation>
+					<xs:documentation>Secondary descriptive blurb taken from the back cover and/or flaps, used only when there are two separate texts and the primary text is included using code 05</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Full cast and credit list</xs:documentation>
+					<xs:documentation>For use with dramatized audiobooks, filmed entertainment etc, for a cast list sent as a single text field, which may or may not carry structure expressed using XHTML</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Bibliography</xs:documentation>
+					<xs:documentation>Complete list of books by the author(s), supplied as a single text field, which may be structured using (X)HTML</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -23950,6 +20036,18 @@
 					<xs:documentation>Date until which a supporting resource is available for download. Note that this date does not imply it must be removed from display to the intended audience on this date – for this, use Until date (code 15)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Associated start date</xs:documentation>
+					<xs:documentation>Start date referenced by the supporting resource, for example, the ‘earliest exam date’ for an official recommendation</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Associated end date</xs:documentation>
+					<xs:documentation>End date referenced by the supporting resource, for example, the ‘latest exam date’ for an official recommendation</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List156">
@@ -23979,6 +20077,12 @@
 				<xs:annotation>
 					<xs:documentation>‘One locality, one book’ program</xs:documentation>
 					<xs:documentation>(North America) Inclusion in a program such as ‘Chicago Reads’, ‘Seattle Reads’</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Curated list</xs:documentation>
+					<xs:documentation>For example a ‘best books of the year’ or ‘25 books you should have read’ list, without regard to their bestseller status</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -24106,7 +20210,7 @@
 			<xs:enumeration value="15">
 				<xs:annotation>
 					<xs:documentation>Sample content</xs:documentation>
-					<xs:documentation>For example: sample chapter text, page images, screenshots</xs:documentation>
+					<xs:documentation>For example: a short excerpt, sample text or a complete sample chapter, page images, screenshots etc</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="16">
@@ -24251,6 +20355,30 @@
 				<xs:annotation>
 					<xs:documentation>Instructional material</xs:documentation>
 					<xs:documentation>For example, video showing how to use the product</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Errata</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Introduction</xs:documentation>
+					<xs:documentation>Introduction, preface or other preliminary material in a separate resource file</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Collection description</xs:documentation>
+					<xs:documentation>Descriptive material in a separate resource file, not in the ONIX record. Equivalent of code 17 in List 153. Use the &lt;TextContent&gt; composite for collection descriptions carried in the ONIX record. Use &lt;Supporting Resource&gt; for material (which need not be solely only) offered as a separate file resource for reproduction as part of promotional material for the product and collection</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Bibliography</xs:documentation>
+					<xs:documentation>Complete list of books by the author(s), supplied as a separate resource file</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="99">
@@ -24398,7 +20526,7 @@
 			<xs:enumeration value="04">
 				<xs:annotation>
 					<xs:documentation>Filename</xs:documentation>
-					<xs:documentation>Resource Version Feature Value carries the filename of the supporting resource</xs:documentation>
+					<xs:documentation>Resource Version Feature Value carries the filename of the supporting resource, necessary only when it is different from the last part of the path provided in &lt;ResourceLink&gt;</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
@@ -24435,31 +20563,31 @@
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Publication date</xs:documentation>
-					<xs:documentation>Nominal date of publication</xs:documentation>
+					<xs:documentation>Nominal date of publication. This date is primarily used for planning, promotion and other business process purposes, and is not necessarily the first date for retail sales or fulfillment of pre-orders. In the absence of a sales embargo date, retail sales and pre-order fulfillment may begin as soon as stock is available to the retailer</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
-					<xs:documentation>Embargo date</xs:documentation>
-					<xs:documentation>If there is an embargo on retail sales in this market before a certain date, the date from which the embargo is lifted and retail sales are permitted</xs:documentation>
+					<xs:documentation>Sales embargo date</xs:documentation>
+					<xs:documentation>If there is an embargo on retail sales (in the market) before a certain date, the date from which the embargo is lifted and retail sales and fulfillment of pre-orders are permitted. In the absence of an embargo date, retail sales and pre-order fulfillment may begin as soon as stock is available to the retailer</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="09">
 				<xs:annotation>
 					<xs:documentation>Public announcement date</xs:documentation>
-					<xs:documentation>Date when a new product may be announced to the general public</xs:documentation>
+					<xs:documentation>Date when a new product may be announced to the general public. In the absence of an announcement date, the planned product may be announced to the public as soon as metadata is available</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="10">
 				<xs:annotation>
 					<xs:documentation>Trade announcement date</xs:documentation>
-					<xs:documentation>Date when a new product may be announced for trade only</xs:documentation>
+					<xs:documentation>Date when a new product may be announced to the book trade only. In the absence of a trade announcement date, the planned product may be announced to supply chain partners (but not necessarily made public) as soon as metadata is available</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="11">
 				<xs:annotation>
 					<xs:documentation>Date of first publication</xs:documentation>
-					<xs:documentation>Date when the work incorporated in a product was first published</xs:documentation>
+					<xs:documentation>Date when the work incorporated in a product was first published. For works in translation, see also Date of first publication in original language (code 20)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="12">
@@ -24483,13 +20611,13 @@
 			<xs:enumeration value="19">
 				<xs:annotation>
 					<xs:documentation>Publication date of print counterpart</xs:documentation>
-					<xs:documentation>Date of publication of a printed book which is the print counterpart to a digital edition</xs:documentation>
+					<xs:documentation>Date of publication of a printed book which is the direct print counterpart to a digital product. The counterpart product may be included in &lt;RelatedProduct&gt; using code 13</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="20">
 				<xs:annotation>
 					<xs:documentation>Date of first publication in original language</xs:documentation>
-					<xs:documentation>Year when the original language version of work incorporated in a product was first published (note, use only when different from code 11)</xs:documentation>
+					<xs:documentation>Date when the original language version of work incorporated in a product was first published (note, use only on works in translation – see code 11 for first publication date in the translated language)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="21">
@@ -24525,7 +20653,7 @@
 			<xs:enumeration value="27">
 				<xs:annotation>
 					<xs:documentation>Preorder embargo date</xs:documentation>
-					<xs:documentation>Earliest date a retail ‘preorder’ can be placed (where this is distinct from the public announcement date). In the absence of a preorder embargo, advance orders can be placed as soon as metadata is available to the consumer (this would be the public announcement date, or in the absence of a public announcement date, the earliest date metadata is available to the retailer)</xs:documentation>
+					<xs:documentation>Earliest date a retail ‘preorder’ can be placed (in the market), where this is distinct from the public announcement date. In the absence of a preorder embargo, advance orders can be placed as soon as metadata is available to the consumer (this would be the public announcement date, or in the absence of a public announcement date, the earliest date metadata is available to the retailer)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="28">
@@ -24540,29 +20668,41 @@
 					<xs:documentation>For an audiovisual work (eg on DVD)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Streaming embargo date</xs:documentation>
+					<xs:documentation>For digital products that are available to end customers both as a download and streamed, the earliest date the product can be made available on a stream, where the streamed version becomes available later than the download. For the download, see code 02 if it is embargoed or code 01 if there is no embargo</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Subscription embargo date</xs:documentation>
+					<xs:documentation>For digital products that are available to end customers both as purchases and as part of a subscription package, the earliest date the product can be made available by subscription, where the product may not be included in a subscription package until shome while after publication. For ordinary sales, see code 02 if there is a sales embargo or code 01 if there is no embargo</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List164">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 164">Work relation code</xs:documentation>
+			<xs:documentation source="ONIX Code List 164">Work relation</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Manifestation of</xs:documentation>
-					<xs:documentation>Product X is or includes a manifestation of work Y</xs:documentation>
+					<xs:documentation>Product X is or includes a manifestation of work Y. (There is a direct parent-child relation between work Y and the product)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
 				<xs:annotation>
 					<xs:documentation>Derived from</xs:documentation>
-					<xs:documentation>Product X is or includes a manifestation of a work derived (directly) from related work Y in one or more of the ways specified in ISTC rules. This relation type is intended to enable products with a common ‘parent’ work to be linked without specifying the precise nature of their derivation</xs:documentation>
+					<xs:documentation>Product X is or includes a manifestation of a work derived (directly) from related work Y in one or more of the ways specified in ISTC rules. (There is a relationship between a grandparent work Y and a prent work, and between that parent work and the product.) This relation type is intended to enable products with a common ‘grandparent’ work to be linked without specifying the precise nature of their derivation, and without necessarily assigning an identifier to the product’s parent</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>Related work is derived from this</xs:documentation>
-					<xs:documentation>Product X is a manifestation of a work from which related work Y is (directly) derived in one or more of the ways specified in ISTC rules (reciprocal of code 02)</xs:documentation>
+					<xs:documentation>Product X is a manifestation of a work from which related work Y is (directly) derived in one or more of the ways specified in ISTC rules. (There is a relationship between a parent work and a child work Y, and between the parent work and the product)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="04">
@@ -24629,14 +20769,14 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="02">
 				<xs:annotation>
-					<xs:documentation>Embargo date</xs:documentation>
-					<xs:documentation>If there is an embargo on retail sales before a certain date, the date from which the embargo is lifted and retail sales are permitted</xs:documentation>
+					<xs:documentation>Sales embargo date</xs:documentation>
+					<xs:documentation>If there is an embargo on retail sales (of copies from the supplier) before a certain date and this is later than any general or market-wide embargo date, the date from which the embargo is lifted and retail sales and fulfillment of pre-orders are permitted. Use code 02 here ONLY in the exceptional case when the embargo is supplier-specific. More general market-wide or global sales embargos should be specified in &lt;MarketDate&gt; or &lt;PublishingDate&gt; codes. In the absence of any supplier-specific, market-wide or general embargo date, retail sales and pre-order fulfillment may begin as soon as stock is available to the retailer</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Expected availability date</xs:documentation>
-					<xs:documentation>The date on which physical stock is expected to be available to be shipped to retailers, or a digital product is expected to be released by the publisher or digital asset distributor to retailers or their retail platform providers</xs:documentation>
+					<xs:documentation>The date on which physical stock is expected to be available to be shipped from the supplier to retailers, or a digital product is expected to be released by the publisher or digital asset distributor to retailers or their retail platform providers</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="18">
@@ -24649,6 +20789,24 @@
 				<xs:annotation>
 					<xs:documentation>Reservation order deadline</xs:documentation>
 					<xs:documentation>Latest date on which an order may be placed for guaranteed delivery prior to the publication date. May or may not be linked to a special reservation or pre-publication price</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Last redownload date</xs:documentation>
+					<xs:documentation>Latest date on which existing owners or licensees may download or re-download a copy of the product. Existing users may continue to use their local copy of the product</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Last TPM date</xs:documentation>
+					<xs:documentation>Date on which any required technical protection measures (DRM) support will be withdrawn. DRM-protected products may not be usable after this date</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Expected warehouse date</xs:documentation>
+					<xs:documentation>The date on which physical stock is expected to be delivered to the supplier from the manufacturer or from a primary distributor. For the distributor or wholesaler (the supplier) this is the ‘goods in’ date, as contrasted with the Expected availability date, code 08, which is the ‘goods out’ date</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="50">
@@ -24692,6 +20850,12 @@
 				<xs:annotation>
 					<xs:documentation>Updates available</xs:documentation>
 					<xs:documentation>Updates may be purchased separately, no minimum commitment required</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Linked subsequent purchase price</xs:documentation>
+					<xs:documentation>Purchase at this price requires commitment to purchase specified other product, not included in price</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="05">
@@ -24743,6 +20907,12 @@
 					<xs:documentation>The price condition quantity is a number of updates</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Number of linked products</xs:documentation>
+					<xs:documentation>Use with Price condition type 06 and a Quantity of units. Price is valid when purchased with a specific number of products from a list of product identifiers provided in the associated &lt;ProductIdentifier&gt; composites. Use for example when describing a price for this product which is valid if it is purchased along with any two from a list of other products</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List169">
@@ -24790,7 +20960,7 @@
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Rising discount</xs:documentation>
-					<xs:documentation>Discount applied to all units in a qualifying order</xs:documentation>
+					<xs:documentation>Discount applied to all units in a qualifying order. The default if no &lt;DiscountType&gt; is specified</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="02">
@@ -24833,7 +21003,7 @@
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>ECO</xs:documentation>
-					<xs:documentation>‘Green’ or eco-tax, levied to encourage responsible production or disposal, used only where this is identified separately from value-added or sales taxes (eg French éco-participation tax)</xs:documentation>
+					<xs:documentation>‘Green’ or eco-tax, levied to encourage responsible production or disposal, used only where this is identified separately from value-added or sales taxes</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -24846,7 +21016,7 @@
 			<xs:enumeration value="EUR">
 				<xs:annotation>
 					<xs:documentation>Eurozone</xs:documentation>
-					<xs:documentation>Countries that at the time being have the Euro as their national currency. Deprecated in ONIX 3</xs:documentation>
+					<xs:documentation>Countries that at the time being have the Euro as their national currency. Deprecated</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -25077,7 +21247,7 @@
 			<xs:enumeration value="A410">
 				<xs:annotation>
 					<xs:documentation>Mono</xs:documentation>
-					<xs:documentation>Includes 'stereo' where channels are identical</xs:documentation>
+					<xs:documentation>Includes ‘stereo’ where channels are identical</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="A420">
@@ -25107,19 +21277,19 @@
 			<xs:enumeration value="B101">
 				<xs:annotation>
 					<xs:documentation>Mass market (rack) paperback</xs:documentation>
-					<xs:documentation>In North America, a category of paperback characterized partly by page size (typically 4¼ x 7 1/8 inches) and partly by target market and terms of trade. Use with Product Form code BC</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterized partly by page size (typically from 6¾ up to 7⅛ x 4¼ inches) and partly by target market and terms of trade. Use with Product Form code BC</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B102">
 				<xs:annotation>
 					<xs:documentation>Trade paperback (US)</xs:documentation>
-					<xs:documentation>In North America, a category of paperback characterized partly by page size and partly by target market and terms of trade. AKA ‘quality paperback’, and including textbooks. Most paperback books sold in North America except ‘mass-market’ (B101) and ‘tall rack’ (B107) are correctly described with this code. Use with Product Form code BC</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterized partly by page size (larger than rack-sized) and partly by target market and terms of trade. AKA ‘quality paperback’, and including textbooks. Most paperback books sold in North America except ‘mass-market’ (B101) and ‘tall rack’ (B107) are correctly described with this code. Use with Product Form code BC</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B103">
 				<xs:annotation>
 					<xs:documentation>Digest format paperback</xs:documentation>
-					<xs:documentation>In North America, a category of paperback characterized by page size and generally used for children’s books; use with Product Form code BC. Note: was wrongly shown as B102 (duplicate entry) in Issue 3</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterized by page size (typically 7 x 5 inches) and generally used for children’s books; use with Product Form code BC. Note: was wrongly shown as B102 (duplicate entry) in Issue 3</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B104">
@@ -25137,37 +21307,37 @@
 			<xs:enumeration value="B106">
 				<xs:annotation>
 					<xs:documentation>Trade paperback (UK)</xs:documentation>
-					<xs:documentation>In UK, a category of paperback characterized partly by size (usually in traditional hardback dimensions), and often used for paperback originals; use with Product Form code BC (replaces ‘C-format’ from former List 8)</xs:documentation>
+					<xs:documentation>In UK, a category of paperback characterized largely by size (usually in traditional hardback dimensions), and often used for paperback originals or retailer/travel/export-exclusives; use with Product Form code BC</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B107">
 				<xs:annotation>
 					<xs:documentation>Tall rack paperback (US)</xs:documentation>
-					<xs:documentation>In North America, a category of paperback characterised partly by page size and partly by target market and terms of trade; use with Product Form code BC</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterised partly by page size (typically 7½ x 4¼ inches) and partly by target market and terms of trade; use with Product Form code BC</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B108">
 				<xs:annotation>
 					<xs:documentation>A5 size Tankobon</xs:documentation>
-					<xs:documentation>210x148mm</xs:documentation>
+					<xs:documentation>Japanese A-series size, 210 x 148mm. A tankobon is a complete collected story originally published in serialised form (eg in a magazine)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B109">
 				<xs:annotation>
 					<xs:documentation>JIS B5 size Tankobon</xs:documentation>
-					<xs:documentation>Japanese B-series size, 257x182mm</xs:documentation>
+					<xs:documentation>Japanese B-series size, 257 x 182mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B110">
 				<xs:annotation>
 					<xs:documentation>JIS B6 size Tankobon</xs:documentation>
-					<xs:documentation>Japanese B-series size, 182x128mm</xs:documentation>
+					<xs:documentation>Japanese B-series size, 182 x 128mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B111">
 				<xs:annotation>
 					<xs:documentation>A6 size Bunko</xs:documentation>
-					<xs:documentation>148x105mm</xs:documentation>
+					<xs:documentation>Japanese A-series size, 148 x 105mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B112">
@@ -25185,7 +21355,7 @@
 			<xs:enumeration value="B114">
 				<xs:annotation>
 					<xs:documentation>Storpocket (Sweden)</xs:documentation>
-					<xs:documentation>A Swedish paperback format, use with Product Form Code BC</xs:documentation>
+					<xs:documentation>A Swedish paperback format, use with Product Form Code BC. In Finnish, Jättipokkari</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B115">
@@ -25209,67 +21379,67 @@
 			<xs:enumeration value="B118">
 				<xs:annotation>
 					<xs:documentation>Dwarsligger</xs:documentation>
-					<xs:documentation>Also called ‘Flipback’. A softback book in a specially compact proprietary format with pages printed in landscape on very thin paper and bound along the long (top) edge – see www.dwarsligger.com</xs:documentation>
+					<xs:documentation>Also called ‘Flipback’. A softback book in a specially compact proprietary format with pages printed in landscape on very thin paper and bound along the long (top) edge (ie parallel with the lines of text). Use with Product Form code BC – see www.dwarsligger.com</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B119">
 				<xs:annotation>
 					<xs:documentation>46 size</xs:documentation>
-					<xs:documentation>Japanese format: 188x127mm</xs:documentation>
+					<xs:documentation>Japanese format, 188 x 127mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B120">
 				<xs:annotation>
 					<xs:documentation>46-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
+					<xs:documentation>Japanese format, 188 x 127mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B121">
 				<xs:annotation>
 					<xs:documentation>A4</xs:documentation>
-					<xs:documentation>297x210mm</xs:documentation>
+					<xs:documentation>297 x 210mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B122">
 				<xs:annotation>
 					<xs:documentation>A4-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
+					<xs:documentation>Japanese format, 297 x 210mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B123">
 				<xs:annotation>
 					<xs:documentation>A5-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
+					<xs:documentation>Japanese format, 210 x 146mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B124">
 				<xs:annotation>
 					<xs:documentation>B5-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
+					<xs:documentation>Japanese format, 257 x 182mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B125">
 				<xs:annotation>
 					<xs:documentation>B6-Henkei size</xs:documentation>
-					<xs:documentation>Japanese format</xs:documentation>
+					<xs:documentation>Japanese format, 182 x 128mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B126">
 				<xs:annotation>
 					<xs:documentation>AB size</xs:documentation>
-					<xs:documentation>257x210mm</xs:documentation>
+					<xs:documentation>257 x 210mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B127">
 				<xs:annotation>
 					<xs:documentation>JIS B7 size</xs:documentation>
-					<xs:documentation>Japanese B-series size, 128x91mm</xs:documentation>
+					<xs:documentation>Japanese B-series size, 128 x 91mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B128">
 				<xs:annotation>
 					<xs:documentation>Kiku size</xs:documentation>
-					<xs:documentation>Japanese format: 218x152mm or 227x152mm</xs:documentation>
+					<xs:documentation>Japanese format, 218 x 152mm or 227 x 152mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B129">
@@ -25281,13 +21451,31 @@
 			<xs:enumeration value="B130">
 				<xs:annotation>
 					<xs:documentation>JIS B4 size</xs:documentation>
-					<xs:documentation>Japanese B-series size, 257x364mm</xs:documentation>
+					<xs:documentation>Japanese B-series size, 364 x 257 mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B131">
 				<xs:annotation>
 					<xs:documentation>Paperback (DE)</xs:documentation>
-					<xs:documentation>German paperback format, greater than 205mm high, with flaps. Use with Product form code BC</xs:documentation>
+					<xs:documentation>German large paperback format, greater than about 205mm high, with flaps. Use with Product form code BC</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B132">
+				<xs:annotation>
+					<xs:documentation>Libro de bolsillo</xs:documentation>
+					<xs:documentation>Spanish pocket paperback. Use with Product form code BC</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B133">
+				<xs:annotation>
+					<xs:documentation>Pocket-sized</xs:documentation>
+					<xs:documentation>German ,Taschenbuch‘, Italian «Tascabile / Supertascabile» pocket-sized format, usually less than about 205mm high. Use with Product form code BB or BC</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B134">
+				<xs:annotation>
+					<xs:documentation>A5</xs:documentation>
+					<xs:documentation>210 x 148mm</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B201">
@@ -25368,6 +21556,12 @@
 					<xs:documentation>A book with detachable felt pieces and textured pages on which they can be arranged</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="B216">
+				<xs:annotation>
+					<xs:documentation>Press-out puzzle pieces</xs:documentation>
+					<xs:documentation>A book containing pages with die-cut or press-out pieces that can be used as a jigsaw, puzzle pieces, etc</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="B221">
 				<xs:annotation>
 					<xs:documentation>Picture book</xs:documentation>
@@ -25376,8 +21570,14 @@
 			</xs:enumeration>
 			<xs:enumeration value="B222">
 				<xs:annotation>
-					<xs:documentation>‘Carousel’ Book</xs:documentation>
+					<xs:documentation>‘Carousel’ book</xs:documentation>
 					<xs:documentation>(aka ‘Star’ book). Tax treatment of products may differ from that of products with similar codes such as Book as toy or Pop-up book)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B223">
+				<xs:annotation>
+					<xs:documentation>Pull-the-tab book</xs:documentation>
+					<xs:documentation>A book with movable card ‘tabs’ within the pages. Pull a tab to reveal or animate part of a picture (distinct from a ‘lift-the-flap’ book, where flaps simply reveal hidden pictures, and not a ‘pop-up’ book with 3D paper engineering)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B301">
@@ -25425,13 +21625,13 @@
 			<xs:enumeration value="B308">
 				<xs:annotation>
 					<xs:documentation>Half bound</xs:documentation>
-					<xs:documentation>Must be accompanied by a code specifiying a material, eg ‘half-bound real leather’</xs:documentation>
+					<xs:documentation>Highest qualiy material used on spine and corners only. Must be accompanied by a code specifiying a material, eg ‘half-bound real leather’</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B309">
 				<xs:annotation>
 					<xs:documentation>Quarter bound</xs:documentation>
-					<xs:documentation>Must be accompanied by a code specifiying a material, eg ‘quarter bound real leather’</xs:documentation>
+					<xs:documentation>Highest qualiy material used on spine only. Must be accompanied by a code specifiying a material, eg ‘quarter bound real leather’</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B310">
@@ -25455,7 +21655,7 @@
 			<xs:enumeration value="B313">
 				<xs:annotation>
 					<xs:documentation>Concealed wire</xs:documentation>
-					<xs:documentation>Cased over Coiled or Wire-O binding: use with Product Form code BE and Product Form Detail code B312 or B315</xs:documentation>
+					<xs:documentation>Cased over Coiled or Wire-O binding: use with Product Form code BE and Product Form Detail code B312 or B314</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B314">
@@ -25491,37 +21691,37 @@
 			<xs:enumeration value="B401">
 				<xs:annotation>
 					<xs:documentation>Cloth over boards</xs:documentation>
-					<xs:documentation>AKA fabric, linen over boards</xs:documentation>
+					<xs:documentation>Cotton, linen or other woven fabric over boards. Use with &lt;ProductForm&gt; BB</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B402">
 				<xs:annotation>
 					<xs:documentation>Paper over boards</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Cellulose-based or similar non-woven material, which may be printed and may be embossed with an artificial cloth or leather-like texture, over boards. Use with &lt;ProductForm&gt; BB</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B403">
 				<xs:annotation>
 					<xs:documentation>Leather, real</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Covered with leather created by tanning animal hide. May be ‘full-grain’ using the entire thickness of the hide, ‘top grain’ using the outer layer of the hide, or ‘split’ using the inner layers of the hide. Split leather may be embossed with an artificial grain or texture. Use with &lt;ProductForm&gt; BG, and if appropriate with codes B308 or B309 (otherwise ‘full-bound’ is implied)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B404">
 				<xs:annotation>
 					<xs:documentation>Leather, imitation</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Covered with synthetic leather-like material – polymer or non-animal fibre over a textile backing, usually coated and embossed with an artificial grain or texture. Leatherette, pleather etc. Use with &lt;ProductForm&gt; BB (or BG if particularly high-quality), and if appropriate with codes B308 or B309 (otherwise ‘full-bound’ is implied)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B405">
 				<xs:annotation>
 					<xs:documentation>Leather, bonded</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Covered with leather reconstituted from a pulp made from shredded animal hide, layered on a fibre or textile backing, coated and usually embossed with an artificial grain or texture. Use with &lt;ProductForm&gt; BG, and if appropriate with codes B308 or B309 (otherwise ‘full-bound’ is implied)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B406">
 				<xs:annotation>
 					<xs:documentation>Vellum</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>Pages made with prepared but untanned animal skin (usually calf, occasionally goat or sheep). Includes parchment, a thicker and less refined form of animal skin, but not ‘paper vellum’ or vegetable parchment made from synthetic or plant fibres</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B409">
@@ -25570,6 +21770,12 @@
 				<xs:annotation>
 					<xs:documentation>Card cover</xs:documentation>
 					<xs:documentation>With card cover (like a typical paperback). As distinct from a self-cover or more elaborate binding</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B417">
+				<xs:annotation>
+					<xs:documentation>Duplex-printed cover</xs:documentation>
+					<xs:documentation>Printed both inside and outside the front and/or back cover</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B501">
@@ -25656,16 +21862,52 @@
 					<xs:documentation>With one or more pages perforated and intended to be torn out for use</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="B515">
+				<xs:annotation>
+					<xs:documentation>Acid-free paper</xs:documentation>
+					<xs:documentation>Printed on acid-free or alkaline buffered paper conforming with ISO 9706</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B516">
+				<xs:annotation>
+					<xs:documentation>Archival paper</xs:documentation>
+					<xs:documentation>Printed on acid-free or alkaline buffered paper with a high cotton content, conforming with ISO 11108</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B517">
+				<xs:annotation>
+					<xs:documentation>With elasticated strap</xs:documentation>
+					<xs:documentation>Strap acts as closure or as page marker</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B518">
+				<xs:annotation>
+					<xs:documentation>With serialized authenticity token</xs:documentation>
+					<xs:documentation>For example, holographic sticker such as the banderol used in the Turkish book trade</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B519">
+				<xs:annotation>
+					<xs:documentation>With dust jacket poster</xs:documentation>
+					<xs:documentation>Jacket in the form of a pamphlet or poster, specifically intended to be removed and read or used separately from the book</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="B601">
 				<xs:annotation>
 					<xs:documentation>Turn-around book</xs:documentation>
-					<xs:documentation>A book in which half the content is printed upside-down, to be read the other way round. Also known as a ‘flip-book’, ‘back-to-back’, (fr.) ‘tête-bêche’ (usually an omnibus of two works)</xs:documentation>
+					<xs:documentation>A book in which half the content is printed upside-down, to be read the other way round. Also known as a ‘flip-book’ or ‘tête-bêche’ (Fr) binding, it has two front covers and a single spine. Usually an omnibus of two works</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B602">
 				<xs:annotation>
 					<xs:documentation>Unflipped manga format</xs:documentation>
 					<xs:documentation>Manga with pages and panels in the sequence of the original Japanese, but with Western text</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B603">
+				<xs:annotation>
+					<xs:documentation>Back-to-back book</xs:documentation>
+					<xs:documentation>A book in which half the content is printed so as to be read from the other cover. All content is printed the same way up. Also known as ‘dos-à-dos’ (Fr) binding, it has two front covers and two spines. Usually an omnibus of two works</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B610">
@@ -25689,7 +21931,7 @@
 			<xs:enumeration value="B703">
 				<xs:annotation>
 					<xs:documentation>US Braille</xs:documentation>
-					<xs:documentation>DEPRECATED- use B704/B705 as appropriate instead</xs:documentation>
+					<xs:documentation>For US Braille, prefer codes B704 and B705 as appropriate</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B704">
@@ -25707,13 +21949,25 @@
 			<xs:enumeration value="B706">
 				<xs:annotation>
 					<xs:documentation>Unified English Braille</xs:documentation>
-					<xs:documentation/>
+					<xs:documentation>For UEB, prefer codes B708 and B709 as appropriate</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="B707">
 				<xs:annotation>
 					<xs:documentation>Moon</xs:documentation>
 					<xs:documentation>Moon embossed alphabet, used by some print-impaired readers who have difficulties with Braille</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B708">
+				<xs:annotation>
+					<xs:documentation>Unified English Uncontracted Braille</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B709">
+				<xs:annotation>
+					<xs:documentation>Unified English Contracted Braille</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="D101">
@@ -25983,7 +22237,7 @@
 			<xs:enumeration value="E116">
 				<xs:annotation>
 					<xs:documentation>Amazon Kindle</xs:documentation>
-					<xs:documentation>A format proprietary to Amazon for use with its Kindle reading devices or software readers [File extensions .azw, .mobi, .prc]</xs:documentation>
+					<xs:documentation>A format proprietary to Amazon for use with its Kindle reading devices or software readers [File extensions .azw, .mobi, .prc etc]</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="E117">
@@ -26148,16 +22402,28 @@
 					<xs:documentation>Proprietary format based on PDF used by Barnes and Noble for fixed-format e-books, readable on some NOOK devices and Nook reader software</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="E146">
+				<xs:annotation>
+					<xs:documentation>BRF</xs:documentation>
+					<xs:documentation>Electronic Braille file</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E147">
+				<xs:annotation>
+					<xs:documentation>Erudit</xs:documentation>
+					<xs:documentation>Proprietary XML format for articles, see for example https://www.cairn.info/services-aux-editeurs.php</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="E200">
 				<xs:annotation>
 					<xs:documentation>Reflowable</xs:documentation>
-					<xs:documentation>Use when a particular e-publication type (specified using codes E100 and upwards) has both fixed format and reflowable variants</xs:documentation>
+					<xs:documentation>Use this and/or code E201 when a particular e-publication type (specified using codes E100 and upwards) has both fixed format and reflowable variants, to indicate which option is included in this product</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="E201">
 				<xs:annotation>
 					<xs:documentation>Fixed format</xs:documentation>
-					<xs:documentation>Use when a particular e-publication type (specified using codes E100 and upwards) has both fixed format and reflowable variants</xs:documentation>
+					<xs:documentation>Use this and/or code E200 when a particular e-publication type (specified using codes E100 and upwards) has both fixed format and reflowable variants, to indicate which option is included in this product</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="E202">
@@ -26349,19 +22615,37 @@
 			<xs:enumeration value="V201">
 				<xs:annotation>
 					<xs:documentation>PAL</xs:documentation>
-					<xs:documentation>TV standard for video or DVD</xs:documentation>
+					<xs:documentation>SD TV standard for video or DVD</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="V202">
 				<xs:annotation>
 					<xs:documentation>NTSC</xs:documentation>
-					<xs:documentation>TV standard for video or DVD</xs:documentation>
+					<xs:documentation>SD TV standard for video or DVD</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="V203">
 				<xs:annotation>
 					<xs:documentation>SECAM</xs:documentation>
-					<xs:documentation>TV standard for video or DVD</xs:documentation>
+					<xs:documentation>SD TV standard for video or DVD</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V205">
+				<xs:annotation>
+					<xs:documentation>HD</xs:documentation>
+					<xs:documentation>Up to 2K resolution (1920 or 2048 pixels wide) eg for Blu-Ray</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V206">
+				<xs:annotation>
+					<xs:documentation>UHD</xs:documentation>
+					<xs:documentation>Up to 4K resolution (3840 or 4096 pixels wide) eg for Ultra HD Blu-Ray</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V207">
+				<xs:annotation>
+					<xs:documentation>3D video</xs:documentation>
+					<xs:documentation>Eg for Blu-ray 3D</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="V220">
@@ -26380,7 +22664,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List176">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 176">Product form feature value – operating system</xs:documentation>
+			<xs:documentation source="ONIX Code List 176">Operating system</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -26410,13 +22694,13 @@
 			<xs:enumeration value="05">
 				<xs:annotation>
 					<xs:documentation>Mac OS</xs:documentation>
-					<xs:documentation>[A proprietary operating system supplied by Apple on Macintosh computers up to 2002] DEPRECATED – use code 13 for all Mac OS versions</xs:documentation>
+					<xs:documentation>Proprietary ‘Classic’ operating system supplied by Apple on Macintosh computers up to 2002. DEPRECATED – use code 13 for all Mac OS versions</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
 				<xs:annotation>
 					<xs:documentation>Mac OS X</xs:documentation>
-					<xs:documentation>[A proprietary operating system supplied by Apple on Macintosh computers from 2001/2002] DEPRECATED – use code 13 for all Mac OS versions</xs:documentation>
+					<xs:documentation>Proprietary ‘OS X’ operating system supplied by Apple on Macintosh computers from 2001/2002. DEPRECATED – use code 13 for all Mac OS versions</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="07">
@@ -26529,6 +22813,12 @@
 					<xs:documentation>Advanced Audio Coding format</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="A108">
+				<xs:annotation>
+					<xs:documentation>Ogg/Vorbis</xs:documentation>
+					<xs:documentation>Vorbis audio format in the Ogg container</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="A111">
 				<xs:annotation>
 					<xs:documentation>AIFF</xs:documentation>
@@ -26592,7 +22882,7 @@
 			<xs:enumeration value="D401">
 				<xs:annotation>
 					<xs:documentation>PDF</xs:documentation>
-					<xs:documentation>Portable Document File format</xs:documentation>
+					<xs:documentation>Portable Document File (single page image)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="D501">
@@ -26617,6 +22907,30 @@
 				<xs:annotation>
 					<xs:documentation>TIFF</xs:documentation>
 					<xs:documentation>Tagged Image File format</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D505">
+				<xs:annotation>
+					<xs:documentation>BMP</xs:documentation>
+					<xs:documentation>Windows Bitmap format</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D506">
+				<xs:annotation>
+					<xs:documentation>JP2</xs:documentation>
+					<xs:documentation>JPEG 2000, improved Joint Photographic Experts Group format</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D507">
+				<xs:annotation>
+					<xs:documentation>PSD</xs:documentation>
+					<xs:documentation>Adobe Photoshop native file format, PSD or PSB</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D508">
+				<xs:annotation>
+					<xs:documentation>EPS</xs:documentation>
+					<xs:documentation>Image as Postscript or Encapsulated Postscript file (.ps or .eps)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="E101">
@@ -26702,7 +23016,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List184">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 184">EU Toy Safety Directive hazard warning</xs:documentation>
+			<xs:documentation source="ONIX Code List 184">EU Toy Safety Directive hazard warning type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -26760,10 +23074,34 @@
 			<xs:documentation source="ONIX Code List 196">E-publication Accessibility Details</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Accessibility summary</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription&gt; contains a short explanatory summary of the accessibility of the product, consistent with the more specific conformance and feature details provided. The summary should note both the accessibility features provided and any potential deficiencies. More detailed information may be provided using codes 94–96. For use in ONIX 3.0 only. See also code 00 for a summary of the accessibility features of the product itself</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>LIA Compliance Scheme</xs:documentation>
 					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Accessibility Specification 1.0 A</xs:documentation>
+					<xs:documentation>Conforms with the requirements of EPUB Accessibility Spec 1.0 and WCAG level A. &lt;ProductFormFeatureDescription&gt; may carry a URL linking to a compliance report or certification provided by an independent third party certifier. In the absence of a URL, conformance with the requirements of the Accessibility Specification is self-certified by the publisher</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Accessibility Specification 1.0 AA</xs:documentation>
+					<xs:documentation>Conforms with the requirements of EPUB Accessibility Spec 1.0 and WCAG level AA. &lt;ProductFormFeatureDescription&gt; may carry a URL linking to a compliance report or certification provided by an independent third party certifier. In the absence of a URL, conformance with the requirements of the Accessibility Specification is self-certified by the publisher</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Inaccessible</xs:documentation>
+					<xs:documentation>Known to lack significant features required for broad accessibility. For use in ONIX 3.0 only</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="10">
@@ -26871,7 +23209,7 @@
 			<xs:enumeration value="97">
 				<xs:annotation>
 					<xs:documentation>Compatibility tested</xs:documentation>
-					<xs:documentation>&lt;ProductFormFeatureDescription&gt; carries a short description of compatibility testing carried out for this product, including detailed compatibility with various assistive technology such as third-party screen-reading software</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription&gt; carries the URL of a web page giving a short description of compatibility testing carried out for this product, including detailed compatibility with various assistive technology such as third-party screen-reading software. See also code 00 for a summary of the accessibility features of the product itself</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="98">
@@ -26923,6 +23261,18 @@
 					<xs:documentation>Original publication order, for a republished collection or collected works originally published outside a collection</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Suggested reading order</xs:documentation>
+					<xs:documentation>Where it is different from the title order, publication order, narrative order etc</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Suggested display order</xs:documentation>
+					<xs:documentation>Where it is different from the title order, publication order, narrative order, reading order etc</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List198">
@@ -26930,6 +23280,12 @@
 			<xs:documentation source="ONIX Code List 198">Product contact role</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Metadata contact</xs:documentation>
+					<xs:documentation>For queries and feedback concerning the metadata record itself</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="01">
 				<xs:annotation>
 					<xs:documentation>Accessibility request contact</xs:documentation>
@@ -26964,6 +23320,18 @@
 				<xs:annotation>
 					<xs:documentation>Permissions contact</xs:documentation>
 					<xs:documentation>Eg for requests to reproduce or repurpose parts of the publication</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Return authorisation contact</xs:documentation>
+					<xs:documentation>Eg for use where authorisation must be gained from the publisher rather than the distributor or wholesaler</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>CIP / Legal deposit contact</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -27018,14 +23386,14 @@
 			<xs:enumeration value="07">
 				<xs:annotation>
 					<xs:documentation>Content warning (intolerance)</xs:documentation>
-					<xs:documentation>The publisher warns the product includes content involving intolerance of particular groups (eg religious, ethnic, racial, social)</xs:documentation>
+					<xs:documentation>The publisher warns the product includes content involving intolerance or abuse of particular groups (eg religious, ethnic, racial, social)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="List204">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 204">ONIX Returns conditions code</xs:documentation>
+			<xs:documentation source="ONIX Code List 204">ONIX Returns conditions</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="00">
@@ -27049,7 +23417,7 @@
 			<xs:enumeration value="03">
 				<xs:annotation>
 					<xs:documentation>Sale or return</xs:documentation>
-					<xs:documentation>Contact supplier for applicable returns authorization process. The retailer is invoiced immediately for the goods and pays within the specified credit period, but can return excess unsold inventory to the supplier for full credit at a later date (some kind of returns authorisation process is normally required, and returns of stripped covers or proof of destruction may be allowed instead)</xs:documentation>
+					<xs:documentation>Contact supplier for applicable returns authorization process. The retailer is invoiced immediately for the goods and pays within the specified credit period, but can return excess unsold inventory to the supplier for full credit at a later date (some kind of returns authorisation process is normally required and returns must be in saleable conditon, except when return of stripped covers or proof of destruction may be allowed instead)</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="04">
@@ -27111,7 +23479,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List216">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 216">Velocity</xs:documentation>
+			<xs:documentation source="ONIX Code List 216">Velocity metric</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -27172,7 +23540,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List217">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 217">Price identifier type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 217">Price identifier type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -27221,7 +23589,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List218">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 218">License expression type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 218">License expression type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -27246,13 +23614,13 @@
 	</xs:simpleType>
 	<xs:simpleType name="List219">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 219">Rights type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 219">Rights type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="C">
 				<xs:annotation>
 					<xs:documentation>Copyright</xs:documentation>
-					<xs:documentation>Text or image copyright (normally indicated by the © symbol)</xs:documentation>
+					<xs:documentation>Text or image copyright (normally indicated by the © symbol). The default if no &lt;CopyrightType&gt; is specified</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="P">
@@ -27307,6 +23675,12 @@
 			<xs:enumeration value="116B">
 				<xs:annotation>
 					<xs:documentation>Kindle KF8</xs:documentation>
+					<xs:documentation>Use only with &lt;ProductFormDetail&gt; code E116</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="116C">
+				<xs:annotation>
+					<xs:documentation>Kindle KFX</xs:documentation>
 					<xs:documentation>Use only with &lt;ProductFormDetail&gt; code E116</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
@@ -27426,7 +23800,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List225">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 225">Message / Record status detail code</xs:documentation>
+			<xs:documentation source="ONIX Code List 225">Message / Record status detail</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="000">
@@ -27482,7 +23856,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List227">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 227">Chinese School Grade Code</xs:documentation>
+			<xs:documentation source="ONIX Code List 227">Chinese School Grade</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="P">
@@ -27603,7 +23977,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List228">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 228">Grant identifier type code</xs:documentation>
+			<xs:documentation source="ONIX Code List 228">Grant identifier type</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="01">
@@ -27616,7 +23990,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="List229">
 		<xs:annotation>
-			<xs:documentation source="ONIX Code List 229">Gender code – based on ISO 5218</xs:documentation>
+			<xs:documentation source="ONIX Code List 229">Gender – based on ISO 5218</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="u">
@@ -27647,7 +24021,7 @@
 			<xs:enumeration value="00">
 				<xs:annotation>
 					<xs:documentation>No constraints</xs:documentation>
-					<xs:documentation>Allows positive indication that there are no conditions (the default if &lt;PriceConstraint&gt; is omitted)</xs:documentation>
+					<xs:documentation>Allows positive indication that there are no additional constraints (other than those specified in &lt;EpubUsageConstraint&gt;) – the default if &lt;PriceConstraint&gt; is omitted</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="06">
@@ -27659,13 +24033,433 @@
 			<xs:enumeration value="07">
 				<xs:annotation>
 					<xs:documentation>Time-limited license</xs:documentation>
-					<xs:documentation>E-publication license is time-limited. Use with code 02 from List 146 and a number of days in &lt;PriceConstraintLimit&gt;. The purchased copy becomes unusable when the license expires</xs:documentation>
+					<xs:documentation>E-publication license is time-limited. Use with code 02 from List 146 and a time period in days, weeks or months in &lt;PriceConstraintLimit&gt;. The purchased copy becomes unusable when the license expires</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="08">
 				<xs:annotation>
 					<xs:documentation>Loan renewal</xs:documentation>
-					<xs:documentation>Maximum number of consecutive loans (eg from a library) to a single device owner, account holder or patron. Note that a limit of 1 indicates that a loan cannot be renewed</xs:documentation>
+					<xs:documentation>Maximum number of consecutive loans or loan extensions (eg from a library) to a single device owner, account holder or patron. Note that a limit of 1 indicates that a loan cannot be renewed or extended</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Multi-user license</xs:documentation>
+					<xs:documentation>E-publication license is multi-user. Maximum number of concurrent users licensed to use the product should be given in &lt;PriceConstraintLimit&gt;</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Preview on premises</xs:documentation>
+					<xs:documentation>Preview locally before purchase. Allows a retail customer, account holder or patron to view a proportion of the book (or the whole book, if no proportion is specified) before purchase, but ONLY while located physically in the retailer’s store (eg while logged on to the store wifi). Also applies to borrowers making use of ‘acquisition on demand’ models in libraries</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List238">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 238">Brazil educational level</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="K">
+				<xs:annotation>
+					<xs:documentation>Educação Infantil</xs:documentation>
+					<xs:documentation>Preschool and kindergarten</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>Fundamental I 1º ano</xs:documentation>
+					<xs:documentation>Elementary school</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>Fundamental I 2º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>Fundamental I 3º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>Fundamental I 4º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="5">
+				<xs:annotation>
+					<xs:documentation>Fundamental I 5º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="6">
+				<xs:annotation>
+					<xs:documentation>Fundamental II 6º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="7">
+				<xs:annotation>
+					<xs:documentation>Fundamental II 7º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="8">
+				<xs:annotation>
+					<xs:documentation>Fundamental II 8º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="9">
+				<xs:annotation>
+					<xs:documentation>Fundamental II 9º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Ensino Médio 1º ano</xs:documentation>
+					<xs:documentation>High school</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Ensino Médio 2º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Ensino Médio 3º ano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Ensino Técnico Integrado</xs:documentation>
+					<xs:documentation>Technical study at High school, alongside 2nd and 3rd year</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Ensino Técnico Concomitante</xs:documentation>
+					<xs:documentation>Technical study at separate institution in parallel with 2nd and 3rd year High school study</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Ensino Técnico Subsequente</xs:documentation>
+					<xs:documentation>Technical study after completion of High school</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P">
+				<xs:annotation>
+					<xs:documentation>Ensino pré-vestibular</xs:documentation>
+					<xs:documentation>University entrance</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A">
+				<xs:annotation>
+					<xs:documentation>Ensino Superior Graduação Licenciatura/ Bacharelado</xs:documentation>
+					<xs:documentation>Undergraduate degree level</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B">
+				<xs:annotation>
+					<xs:documentation>Ensino Superior Graduação Tecnologia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D">
+				<xs:annotation>
+					<xs:documentation>Ensino Superior Pós-graduação Stricto sensu</xs:documentation>
+					<xs:documentation>Masters and Doctoral degree level</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="F">
+				<xs:annotation>
+					<xs:documentation>Ensino Superior Pós-graduação Lato sensu</xs:documentation>
+					<xs:documentation>Professional qualifications</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List239">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 239">Supply contact role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Return authorisation contact</xs:documentation>
+					<xs:documentation>Eg for use where authorisation must be gained from the supplier (distributor or wholesaler)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="99">
+				<xs:annotation>
+					<xs:documentation>Customer services contact</xs:documentation>
+					<xs:documentation>For general enquiries</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List240">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 240">AV Item type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Audiovisual work</xs:documentation>
+					<xs:documentation>A complete audiovisual work which is published as a content item in a product which carries two or more such works, eg when two or three AV works are published in a single omnibus package</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Front matter</xs:documentation>
+					<xs:documentation>Audiovisual components such as a scene index or introduction which appear before the main content of the product</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Body matter</xs:documentation>
+					<xs:documentation>Audiovisual components such as scenes or ‘chapters’ which appear as part of the main body of the AV material in the product</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>End matter</xs:documentation>
+					<xs:documentation>Audiovisual components such as advertising which appear after the main content of the product</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List241">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 241">AV Item Identifier type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Proprietary</xs:documentation>
+					<xs:documentation>For example, a publisher’s own identifier. Note that &lt;IDTypeName&gt; is required with proprietary identifiers</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>GTIN-13</xs:documentation>
+					<xs:documentation>Formerly known as the EAN-13 (unhyphenated)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>DOI</xs:documentation>
+					<xs:documentation>Digital Object Identifier (variable length and character set beginning ‘10.’, and without https://doi.org/ or the older http://dx.doi.org/)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>IMDB</xs:documentation>
+					<xs:documentation>Motion picture work identifier from the International Movie Database</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>ISRC</xs:documentation>
+					<xs:documentation>International Standard Recording Code, 5 alphanumeric characters plus 7 digits</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>ISAN</xs:documentation>
+					<xs:documentation>International Standard Audiovisual Number, 16 or 26 hex digits, with optional alphanumeric check character(s), unhyphenated</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>EIDR DOI</xs:documentation>
+					<xs:documentation>Entertainment Identifier Registry DOI</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List242">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 242">Battery type and safety</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Batteries not required</xs:documentation>
+					<xs:documentation>The default if battery type and safety information is omitted</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Batteries built in</xs:documentation>
+					<xs:documentation>Batteries built in or pre-installed in product, non-user replaceable. May use &lt;ProductFormFeatureDesciption&gt; to provide further details</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Batteries pre-installed</xs:documentation>
+					<xs:documentation>Batteries pre-installed, user replaceable. Use &lt;ProductFormFeatureDescription&gt; to provide further details, eg ‘2 x 1.2V LR6/AA rechargeable’, with these details formatted as [integer] x [number]V [type or descriptive text] and usually taken from the outer packaging</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Batteries supplied</xs:documentation>
+					<xs:documentation>Batteries included with the product, but not pre-installed. Use &lt;ProductFormFeatureDescription&gt; to provide further details, eg ‘2 x 1.2V LR6/AA rechargeable’, with these details formatted as [integer] x [number]V [type or descriptive text] and usually taken from the outer packaging</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Batteries required</xs:documentation>
+					<xs:documentation>Batteries required for use, but not supplied with the product. May use &lt;ProductFormFeatureDescription&gt; to provide further details, eg ‘2 x 1.2V LR6/AA rechargeable’, with these details formatted as [integer] x [number]V [type or descriptive text] and usually taken from the outer packaging</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Batteries supplied spare</xs:documentation>
+					<xs:documentation>Spare batteries included with product, in addition to those specified using codes 02 or 03. May use &lt;ProductFormFeatureDescription&gt; to provide further details</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Safety data sheet available</xs:documentation>
+					<xs:documentation>(Material) Safety Data Sheet available for the product (including its batteries). &lt;ProductFormFeatureDescription&gt; must be used to supply URL of documentation</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Technical data sheet available</xs:documentation>
+					<xs:documentation>Battery manufacturer’s technical data sheet available. &lt;ProductFormFeatureDescription&gt; must be used to supply URL of documentation</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Rechargeable</xs:documentation>
+					<xs:documentation>Independent of whether charger is supplied as part of the product. Note that this is largely dependent on battery chemistry, but should be specified separately to avoid ambiguity</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Non-rechargeable</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Battery warning text</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription&gt; contains battery safety-related warning text, generally taken from the outer packaging (eg ‘Warning – internal battery: product must not be pierced’)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Battery chemistry</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription&gt; must provide details of the battery chemistry (eg ‘Sodium-Sulfur’). Use ONLY where no suitable code exists for the specific chemistry used</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Lithium-ion</xs:documentation>
+					<xs:documentation>For all specific battery chemistries, &lt;ProductFormFeatureDescription&gt; may optionally describe the battery construction – for example the nunber of individual cells per battery and any other physical details, eg ‘4 x pouch cells’</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Lithium-polymer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Lithium-metal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Nickel-metal hydride</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Nickel-Cadmium</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Zinc-Manganese dioxide</xs:documentation>
+					<xs:documentation>‘Alkaline battery’</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Zinc-Carbon</xs:documentation>
+					<xs:documentation>Common ‘dry cell’ battery</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Zinc-air</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Silver oxide</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="99">
+				<xs:annotation>
+					<xs:documentation>Battery description</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription&gt; may contain a full description of the batteries supplied (chemistry, cell structure, battery size and weight, number, capacity etc). Use ONLY if the product (or a product part) contains multiple different TYPES of battery that cannot be described with existing codes (eg a mix of battery chemistries or batteries of different sizes, within a single product part)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List243">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 243">Dangerous goods regulations</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Inapplicable</xs:documentation>
+					<xs:documentation>The product is not classed as dangerous goods. The default if information is omitted</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>GHS</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Transport</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Storage</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Waste</xs:documentation>
+					<xs:documentation/>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
@@ -27678,8 +24472,5 @@
 	</xs:simpleType>
 	<xs:simpleType name="TextFormatCode">
 		<xs:restriction base="List34"/>
-	</xs:simpleType>
-	<xs:simpleType name="TransliterationCode">
-		<xs:restriction base="List138"/>
 	</xs:simpleType>
 </xs:schema>

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@
 envlist =
     clean,
     check,
-    {2.6,2.7,3.3,3.4,3.5,pypy},
-    {2.6,2.7,3.3,3.4,3.5,pypy}-nocover,
+    {2.6,2.7,3.4,3.5,3.6},
     report,
     docs
 
@@ -14,10 +13,10 @@ basepython =
     pypy: {env:TOXPYTHON:pypy}
     2.6: {env:TOXPYTHON:python2.6}
     {2.7,docs,spell}: {env:TOXPYTHON:python2.7}
-    3.3: {env:TOXPYTHON:python3.3}
     3.4: {env:TOXPYTHON:python3.4}
     3.5: {env:TOXPYTHON:python3.5}
-    {clean,check,report,extension-coveralls,coveralls,codecov}: python3.4
+    3.6: {env:TOXPYTHON:python3.6}
+    {clean,check,report,extension-coveralls,coveralls,codecov}: python3.6
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -51,7 +50,7 @@ commands =
     sphinx-build -b linkcheck docs dist/docs
 
 [testenv:check]
-basepython = python3.4
+basepython = python3.6
 deps =
     docutils
     check-manifest
@@ -83,7 +82,7 @@ commands =
     codecov []
 
 [testenv:report]
-basepython = python3.4
+basepython = python3.6
 deps = coverage
 skip_install = true
 commands =
@@ -94,34 +93,3 @@ commands =
 commands = coverage erase
 skip_install = true
 deps = coverage
-
-[testenv:2.6-nocover]
-commands =
-    {posargs:py.test -vv --ignore=src}
-usedevelop = false
-
-[testenv:2.7-nocover]
-commands =
-    {posargs:py.test -vv --ignore=src}
-usedevelop = false
-
-[testenv:3.3-nocover]
-commands =
-    {posargs:py.test -vv --ignore=src}
-usedevelop = false
-
-[testenv:3.4-nocover]
-commands =
-    {posargs:py.test -vv --ignore=src}
-usedevelop = false
-
-[testenv:3.5-nocover]
-commands =
-    {posargs:py.test -vv --ignore=src}
-usedevelop = false
-
-[testenv:pypy-nocover]
-commands =
-    {posargs:py.test -vv --ignore=src}
-usedevelop = false
-


### PR DESCRIPTION
I've replaced the `os.getcwdu()` call with the `six` version for Python3 compatibility (now works in Python 3.6) and added the dependency to `setup.py`.

Have also updated the ONIX 3.0 XSDs to the latest from https://www.editeur.org/93/Release-3.0-Downloads/